### PR TITLE
[470833]Cleaning up needless code

### DIFF
--- a/src/org.eclipse.ice.client/src/org/eclipse/ice/client/common/CoreConnectDialog.java
+++ b/src/org.eclipse.ice.client/src/org/eclipse/ice/client/common/CoreConnectDialog.java
@@ -68,7 +68,7 @@ public class CoreConnectDialog extends Dialog {
 		portLabel.setText("Port: ");
 
 		// Create a new text box to input port
-		portField = new Text(comp, SWT.SINGLE | SWT.SINGLE);
+		portField = new Text(comp, SWT.SINGLE);
 		data = new GridData(GridData.FILL_HORIZONTAL);
 		portField.setLayoutData(data);
 


### PR DESCRIPTION
CoreConnectDialog's createDialogArea method contianed unneccesary code
taking the logical OR of a value with itself. This has been removed.

Bug: 470833 https://bugs.eclipse.org/bugs/show_bug.cgi?id=470833
Signed-off-by: Robert Smith <SmithRW@ornl.gov>