### PR TITLE
[470835]Applied Short Circuit Logic in ToolItemMenuListener

### DIFF
--- a/src/org.eclipse.ice.client.widgets.reactoreditor/src/org/eclipse/ice/client/widgets/reactoreditor/ToolItemMenuListener.java
+++ b/src/org.eclipse.ice.client.widgets.reactoreditor/src/org/eclipse/ice/client/widgets/reactoreditor/ToolItemMenuListener.java
@@ -66,7 +66,7 @@ public class ToolItemMenuListener implements Listener {
 
 		// event.detail == SWT.ARROW means the arrow has been clicked.
 		// event.detail == SWT.NONE means the button has been clicked.
-		if (event.detail == SWT.ARROW | event.detail == SWT.NONE) {
+		if (event.detail == SWT.ARROW || event.detail == SWT.NONE) {
 			Rectangle r = toolItem.getBounds();
 			Point p = new Point(r.x, r.y + r.height);
 			p = toolItem.getParent().toDisplay(p.x, p.y);


### PR DESCRIPTION
An instance of ToolItemMenuListener using eager logic instead of short
circuit logic in comparision has been changed. The conditional statement
will now only evaulate the secondary statement if the first returned
false.

Bug: 470835 https://bugs.eclipse.org/bugs/show_bug.cgi?id=470835
Signed-off-by: Robert Smith <SmithRW@ornl.gov>