### PR TITLE
[470844]MeshAppState floating point equality checking repaired

### DIFF
--- a/src/org.eclipse.ice.client.widgets.rcp/src/org/eclipse/ice/client/widgets/mesh/MeshAppState.java
+++ b/src/org.eclipse.ice.client.widgets.rcp/src/org/eclipse/ice/client/widgets/mesh/MeshAppState.java
@@ -1388,7 +1388,7 @@ public class MeshAppState extends ViewAppState implements
 						vSize = vertexSize;
 						vertexSize = (distance < 10f ? 0.0159f * distance + 0.0413f
 								: 0.2f);
-						if (vSize != vertexSize) {
+						if (Math.abs(vSize - vertexSize) > 0.001f) {
 							updateVertices = true;
 							vSize = vertexSize;
 						}
@@ -1398,7 +1398,7 @@ public class MeshAppState extends ViewAppState implements
 						// changed.
 						eSize = edgeSize;
 						edgeSize = (distance < 10f ? 0.1f * distance + 4f : 5f);
-						if (eSize != edgeSize) {
+						if (Math.abs(eSize - edgeSize) > 0.001f) {
 							updateEdges = true;
 							eSize = edgeSize;
 						}


### PR DESCRIPTION
MeshAppState no longer directly tests for the equality of two floating
point numbers. It instead properly takes the absolute value of their
difference and compares it to a small delta value.

Bug: 470844 https://bugs.eclipse.org/bugs/show_bug.cgi?id=470844
Signed-off-by: Robert Smith <SmithRW@ornl.gov>