### PR TITLE
[472380]Repaired SWTBot tests

### DIFF
--- a/tests/org.eclipse.ice.client.widgets.test/pom.xml
+++ b/tests/org.eclipse.ice.client.widgets.test/pom.xml
@@ -13,6 +13,28 @@
 	<artifactId>org.eclipse.ice.client.widgets.test</artifactId>
 	<version>2.0.0</version>
 	<packaging>eclipse-test-plugin</packaging>
+		<build>
+		<plugins>
+			<!-- Configure the build to handle SWTBot -->
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<useUIHarness>true</useUIHarness>
+					<useUIThread>false</useUIThread>
+					<product>org.eclipse.sdk.ide</product>
+					<application>org.eclipse.ui.ide.workbench</application>
+					<dependencies>
+						<dependency>
+							<type>p2-installable-unit</type>
+							<artifactId>org.eclipse.sdk.feature.group</artifactId>
+						</dependency>
+					</dependencies>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<properties>
 		<sonar.skip>true</sonar.skip>
 	</properties>

--- a/tests/org.eclipse.ice.client.widgets.test/src/org/eclipse/ice/client/widgets/test/ICEResourcePageTester.java
+++ b/tests/org.eclipse.ice.client.widgets.test/src/org/eclipse/ice/client/widgets/test/ICEResourcePageTester.java
@@ -45,7 +45,6 @@ import org.junit.Test;
  * @author Jay Jay Billings
  * @author Jordan H. Deyton
  */
-@Ignore
 public class ICEResourcePageTester extends AbstractWorkbenchTester {
 
 	// ---- Resources shared between tests. ---- //

--- a/tests/org.eclipse.ice.viz.service.test/pom.xml
+++ b/tests/org.eclipse.ice.viz.service.test/pom.xml
@@ -26,6 +26,12 @@
 					<useUIThread>false</useUIThread>
 					<product>org.eclipse.sdk.ide</product>
 					<application>org.eclipse.ui.ide.workbench</application>
+					<dependencies>
+						<dependency>
+							<type>p2-installable-unit</type>
+							<artifactId>org.eclipse.sdk.feature.group</artifactId>
+						</dependency>
+					</dependencies>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/tests/org.eclipse.ice.viz.service.test/src/org/eclipse/ice/viz/service/test/PlotEditorTester.java
+++ b/tests/org.eclipse.ice.viz.service.test/src/org/eclipse/ice/viz/service/test/PlotEditorTester.java
@@ -1,19 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2014 UT-Battelle, LLC.
+ * Copyright (c) 2015 UT-Battelle, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Initial API and implementation and/or initial documentation -
+ *   Initial API and implementation and/or initial documentation - 
  *   Robert Smith
  *******************************************************************************/
 package org.eclipse.ice.viz.service.test;
 
-import static org.junit.Assert.fail;
-
-import java.io.File;
+import static org.junit.Assert.*;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -21,24 +19,30 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ice.viz.service.BasicVizServiceFactory;
+import org.eclipse.ice.viz.service.IVizServiceFactory;
+import org.eclipse.ice.viz.service.csv.CSVVizService;
+import org.eclipse.ice.viz.service.internal.VizServiceFactoryHolder;
 import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.jface.bindings.keys.ParseException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarDropDownButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import java.io.File;
 
 /**
  * This class is responsible for testing the PlotEditor class.
- *
+ * 
  * @author Robert Smith
  *
  */
-@Ignore
+
 @RunWith(SWTBotJunit4ClassRunner.class)
 public class PlotEditorTester {
 	/*
@@ -46,12 +50,16 @@ public class PlotEditorTester {
 	 */
 	private static SWTWorkbenchBot bot;
 
+	private static IVizServiceFactory realFactory;
+
 	/*
 	 * Creates the bot before running tests.
 	 */
 	@BeforeClass
 	public static void beforeClass() throws Exception {
 		bot = new SWTWorkbenchBot();
+		realFactory = VizServiceFactoryHolder.getFactory();
+
 	}
 
 	/*
@@ -60,6 +68,11 @@ public class PlotEditorTester {
 	 */
 	@Test
 	public void testPlotEditor() {
+
+		IVizServiceFactory fakeFactory = new BasicVizServiceFactory();
+		fakeFactory.register(new CSVVizService());
+
+		VizServiceFactoryHolder.setVizServiceFactory(fakeFactory);
 
 		// Set up the workspace
 		IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
@@ -129,6 +142,12 @@ public class PlotEditorTester {
 
 		// Test the editor closing menu option.
 		button.menuItem("Close").click();
+
+	}
+
+	@AfterClass
+	public static void afterClass() throws Exception {
+		VizServiceFactoryHolder.setVizServiceFactory(realFactory);
 
 	}
 }


### PR DESCRIPTION
Adds proper dependencies to SWTBot test bundles, allowing them to create
Eclipse instances when launched from Maven to run tests in. It also
changes PlotEditorTester to use a fake IVizServiceFactory, since Maven
does not iniatalize and consume all OSGi services needed for the test.

Signed-off-by: Robert Smith <SmithRW@ornl.gov>
Bug: 472380 https://bugs.eclipse.org/bugs/show_bug.cgi?id=472380