### PR TITLE
Bug 481365 IListPageProvider extension point and a default extension

### DIFF
--- a/org.eclipse.ice.client.widgets/plugin.xml
+++ b/org.eclipse.ice.client.widgets/plugin.xml
@@ -3,6 +3,7 @@
 
 <plugin>
    <extension-point id="org.eclipse.ice.client.widgets.iformwidgetbuilder" name="IForm Widget Builder" schema="schema/iformwidgetbuilder.exsd"/>
+   <extension-point id="org.eclipse.ice.client.widgets.listPageProvider" name="List Page Provider" schema="schema/org.eclipse.ice.client.widgets.listPageProvider.exsd"/>
 
       <extension
          point="org.eclipse.ui.editors">

--- a/org.eclipse.ice.client.widgets/plugin.xml
+++ b/org.eclipse.ice.client.widgets/plugin.xml
@@ -4,6 +4,7 @@
 <plugin>
    <extension-point id="org.eclipse.ice.client.widgets.iformwidgetbuilder" name="IForm Widget Builder" schema="schema/iformwidgetbuilder.exsd"/>
    <extension-point id="org.eclipse.ice.client.widgets.listPageProvider" name="List Page Provider" schema="schema/org.eclipse.ice.client.widgets.listPageProvider.exsd"/>
+   <extension-point id="errorPageProvider" name="Error Page Provider" schema="schema/errorPageProvider.exsd"/>
 
       <extension
          point="org.eclipse.ui.editors">
@@ -378,5 +379,21 @@
              contentTypeId="org.eclipse.ice.persistence.xml.contentType.Form">
        </contentTypeBinding>
     </editor>
+ </extension>
+ <extension
+       id="defaultErrorPageProvider"
+       name="Default Error Page Provider"
+       point="org.eclipse.ice.client.widgets.errorPageProvider">
+    <implementation
+          class="org.eclipse.ice.client.widgets.providers.DefaultErrorPageProvider">
+    </implementation>
+ </extension>
+ <extension
+       id="listPageProvider"
+       name="Default List Page Provider"
+       point="org.eclipse.ice.client.widgets.listPageProvider">
+    <implementation
+          class="org.eclipse.ice.client.widgets.providers.DefaultListPageProvider">
+    </implementation>
  </extension>
 </plugin>

--- a/org.eclipse.ice.client.widgets/schema/errorPageProvider.exsd
+++ b/org.eclipse.ice.client.widgets/schema/errorPageProvider.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.ice.client.widgets" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.ice.client.widgets" id="errorPageProvider" name="Error Page Provider"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="implementation"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="implementation">
+      <complexType>
+         <attribute name="class" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.ice.client.widgets.providers.IErrorPageProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.eclipse.ice.client.widgets/schema/org.eclipse.ice.client.widgets.listPageProvider.exsd
+++ b/org.eclipse.ice.client.widgets/schema/org.eclipse.ice.client.widgets.listPageProvider.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.ice.client.widgets" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.ice.client.widgets" id="org.eclipse.ice.client.widgets.listPageProvider" name="List Page Provider"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="implementation"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="implementation">
+      <complexType>
+         <attribute name="class" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.ice.client.widgets.providers.IListPageProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/DefaultPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/DefaultPageProvider.java
@@ -14,6 +14,7 @@ package org.eclipse.ice.client.widgets;
 import java.util.ArrayList;
 import java.util.Map;
 
+import org.eclipse.ice.client.widgets.providers.IPageProvider;
 import org.eclipse.ice.datastructures.ICEObject.Component;
 import org.eclipse.ui.forms.editor.IFormPage;
 

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
@@ -513,16 +513,20 @@ public class ICEFormEditor extends SharedHeaderFormEditor
 		try {
 			// get all of the registered ListPageProviders
 			IListPageProvider[] listPageProviders = IListPageProvider.getProviders();
-
-			// Use the default list page provider
-			String providerNameToUse = DefaultListPageProvider.PROVIDER_NAME;
-			
-			
-			for (IListPageProvider currentProvider : listPageProviders) {
-				if (providerNameToUse.equals(currentProvider.getName())){
-					pages.addAll(currentProvider.getPages(this, componentMap));
-					break;
+			if (listPageProviders != null && listPageProviders.length > 0) {
+					
+				// Use the default list page provider
+				String providerNameToUse = DefaultListPageProvider.PROVIDER_NAME;
+				
+				
+				for (IListPageProvider currentProvider : listPageProviders) {
+					if (providerNameToUse.equals(currentProvider.getName())){
+						pages.addAll(currentProvider.getPages(this, componentMap));
+						break;
+					}
 				}
+			} else {
+				logger.error("No ListPageProviders registered");
 			}
 		
 		

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
@@ -21,7 +21,9 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.ice.client.widgets.providers.DefaultErrorPageProvider;
 import org.eclipse.ice.client.widgets.providers.DefaultListPageProvider;
+import org.eclipse.ice.client.widgets.providers.IErrorPageProvider;
 import org.eclipse.ice.client.widgets.providers.IListPageProvider;
 import org.eclipse.ice.datastructures.ICEObject.Component;
 import org.eclipse.ice.datastructures.ICEObject.ICEObject;
@@ -1138,9 +1140,33 @@ public class ICEFormEditor extends SharedHeaderFormEditor
 	 */
 	private IFormPage createEmptyErrorPage() {
 
-		// Need IErrorPageProvider
+		IFormPage page = null;
 
-		return new ErrorMessageFormPage(this, "Error Page", "Error Page");
+		try {
+			// get all of the registered ListPageProviders
+			IErrorPageProvider[] errorPageProviders = IErrorPageProvider.getProviders();
+			if (errorPageProviders != null && errorPageProviders.length > 0) {
+
+				// Use the default error page provider
+				String providerNameToUse = DefaultErrorPageProvider.PROVIDER_NAME;
+
+
+				for (IErrorPageProvider currentProvider : errorPageProviders) {
+					if (providerNameToUse.equals(currentProvider.getName())){
+						page = currentProvider.getPage(this, componentMap);
+						break;
+					}
+				}
+			} else {
+				logger.error("No ErrorPageProviders registered");
+			}
+
+		} catch (CoreException e) {
+			logger.error("Unable to get ErrorPageProviders", e);
+		}
+
+		return page;
+
 	}
 
 	/**

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
@@ -21,6 +21,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.ice.client.widgets.providers.DefaultListPageProvider;
+import org.eclipse.ice.client.widgets.providers.IListPageProvider;
 import org.eclipse.ice.datastructures.ICEObject.Component;
 import org.eclipse.ice.datastructures.ICEObject.ICEObject;
 import org.eclipse.ice.datastructures.ICEObject.IUpdateable;
@@ -35,13 +37,13 @@ import org.eclipse.ice.datastructures.form.GeometryComponent;
 import org.eclipse.ice.datastructures.form.MasterDetailsComponent;
 import org.eclipse.ice.datastructures.form.MatrixComponent;
 import org.eclipse.ice.datastructures.form.MeshComponent;
+import org.eclipse.ice.datastructures.form.MeshComponent;
 import org.eclipse.ice.datastructures.form.ResourceComponent;
 import org.eclipse.ice.datastructures.form.TableComponent;
 import org.eclipse.ice.datastructures.form.TimeDataComponent;
 import org.eclipse.ice.datastructures.form.TreeComposite;
 import org.eclipse.ice.datastructures.form.emf.EMFComponent;
 import org.eclipse.ice.datastructures.form.geometry.ICEGeometry;
-import org.eclipse.ice.datastructures.form.MeshComponent;
 import org.eclipse.ice.iclient.IClient;
 import org.eclipse.ice.iclient.uiwidgets.IObservableWidget;
 import org.eclipse.ice.iclient.uiwidgets.IProcessEventListener;
@@ -502,30 +504,30 @@ public class ICEFormEditor extends SharedHeaderFormEditor
 	 * stored in the component map.
 	 * 
 	 * @return The pages.
+	 * @throws CoreException 
 	 */
 	private ArrayList<ICEFormPage> createListSectionPages() {
-
-		// Need IListPageProvider
-
 		// Create the list of pages to return
 		ArrayList<ICEFormPage> pages = new ArrayList<ICEFormPage>();
+		
+		try {
+			// get all of the registered ListPageProviders
+			IListPageProvider[] listPageProviders = IListPageProvider.getProviders();
 
-		// Get the lists from the component map
-		ArrayList<Component> lists = componentMap.get("list");
-		// If there are some lists, render sections for them
-		if (lists.size() > 0) {
-			for (int i = 0; i < lists.size(); i++) {
-				ListComponent<?> list = (ListComponent<?>) lists.get(i);
-				// Make sure the list isn't null since that value can be put in
-				// a collection
-				if (list != null) {
-					// Create a new page for the list
-					ListComponentSectionPage page = new ListComponentSectionPage(this, list.getName(), list.getName());
-					page.setList(list);
-					// Add the page to the return list
-					pages.add(page);
+			// Use the default list page provider
+			String providerNameToUse = DefaultListPageProvider.PROVIDER_NAME;
+			
+			
+			for (IListPageProvider currentProvider : listPageProviders) {
+				if (providerNameToUse.equals(currentProvider.getName())){
+					pages.addAll(currentProvider.getPages(this, componentMap));
+					break;
 				}
 			}
+		
+		
+		} catch (CoreException e) {
+			logger.error("Unable to get ListPageProviders", e);
 		}
 
 		return pages;

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultErrorPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultErrorPageProvider.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014, 2015 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Nick Stanish
+ *******************************************************************************/
+
+package org.eclipse.ice.client.widgets.providers;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.eclipse.ice.client.widgets.ErrorMessageFormPage;
+import org.eclipse.ice.datastructures.ICEObject.Component;
+import org.eclipse.ui.forms.editor.FormEditor;
+import org.eclipse.ui.forms.editor.IFormPage;
+
+/**
+ * This class is a default extension for providing error pages
+ * 
+ * @author Nick Stanish
+ *
+ */
+public class DefaultErrorPageProvider implements IErrorPageProvider {
+
+	public static final String PROVIDER_NAME = "default";
+
+	@Override
+	public String getName() {
+		return PROVIDER_NAME;
+	}
+	
+	@Override
+	public IFormPage getPage(FormEditor formEditor,
+			Map<String, ArrayList<Component>> componentMap) {
+		
+		return new ErrorMessageFormPage(formEditor, "Error Page", "Error Page");
+	}
+
+}

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultListPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultListPageProvider.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014, 2015 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Nick Stanish
+ *******************************************************************************/
+
+package org.eclipse.ice.client.widgets.providers;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.eclipse.ice.client.widgets.ICEFormPage;
+import org.eclipse.ice.client.widgets.ListComponentSectionPage;
+import org.eclipse.ice.datastructures.ICEObject.Component;
+import org.eclipse.ice.datastructures.ICEObject.ListComponent;
+import org.eclipse.ui.forms.editor.FormEditor;
+
+/**
+ * This class is a default extension for providing list section pages
+ * 
+ * @author Nick Stanish
+ *
+ */
+public class DefaultListPageProvider implements IListPageProvider {
+
+	public static final String PROVIDER_NAME = "default";
+
+	@Override
+	public String getName() {
+		return PROVIDER_NAME;
+	}
+
+	@Override
+	public ArrayList<ICEFormPage> getPages(FormEditor formEditor,
+			Map<String, ArrayList<Component>> componentMap) {
+
+		// Get the lists from the component map
+		ArrayList<Component> lists = componentMap.get("list");
+		ArrayList<ICEFormPage> pages = new ArrayList<ICEFormPage>(lists.size());
+
+		// If there are some lists, render sections for them
+		for (int i = 0; i < lists.size(); i++) {
+			ListComponent<?> list = (ListComponent<?>) lists.get(i);
+			// Make sure the list isn't null since that value can be put in
+			// a collection
+			if (list != null) {
+				// Create a new page for the list
+				ListComponentSectionPage page = new ListComponentSectionPage(
+						formEditor, list.getName(), list.getName());
+
+				page.setList(list);
+				// Add the page to the return list
+				pages.add(page);
+			}
+		}
+
+		return pages;
+	}
+
+}

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IErrorPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IErrorPageProvider.java
@@ -19,48 +19,48 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.ice.client.widgets.ICEFormPage;
 import org.eclipse.ice.datastructures.ICEObject.Component;
 import org.eclipse.ui.forms.editor.FormEditor;
+import org.eclipse.ui.forms.editor.IFormPage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This is an interface for list page providers for Form Editors in ICE that provides
- * the set of list section pages required to draw the UI.
+ * This is an interface for error page providers for Form Editors in ICE that provides
+ * the error pages required to draw the UI.
  * 
  * @author Nick Stanish
  *
  */
-public interface IListPageProvider {
+public interface IErrorPageProvider {
 	
-	public static final String EXTENSION_POINT_ID = "org.eclipse.ice.client.widgets.listPageProvider";
+	public static final String EXTENSION_POINT_ID = "org.eclipse.ice.client.widgets.errorPageProvider";
 	
 	
 	/**
 	 * This is a static interface method that returns all of the currently
-	 * registered IListPageProvider.
+	 * registered IErrorPageProvider.
 	 * 
 	 * @return The available providers
 	 * @throws CoreException 
 	 */
-	public static IListPageProvider[] getProviders() throws CoreException {
+	public static IErrorPageProvider[] getProviders() throws CoreException {
 		// Logger for handling event messages and other information.
-		Logger logger = LoggerFactory.getLogger(IListPageProvider.class);
-		IListPageProvider[] listPageProviders = null;
+		Logger logger = LoggerFactory.getLogger(IErrorPageProvider.class);
+		IErrorPageProvider[] errorPageProviders = null;
 		
 		IExtensionPoint point = Platform.getExtensionRegistry().getExtensionPoint(EXTENSION_POINT_ID);
 
 		if (point != null) {
 			IConfigurationElement[] elements = point.getConfigurationElements();
-			listPageProviders = new IListPageProvider[elements.length];
+			errorPageProviders = new IErrorPageProvider[elements.length];
 			for (int i = 0; i < elements.length; i++) {
-				listPageProviders[i] = (IListPageProvider) elements[i].createExecutableExtension("class");
+				errorPageProviders[i] = (IErrorPageProvider) elements[i].createExecutableExtension("class");
 			}
 		} else {
 			logger.error("Extension Point " + EXTENSION_POINT_ID + " does not exist");
 		}
-		return listPageProviders;
+		return errorPageProviders;
 	}
 
 	/**
@@ -87,6 +87,6 @@ public interface IListPageProvider {
 	 *            simulated multimap.
 	 * @return the form pages created from the map
 	 */
-	public ArrayList<ICEFormPage> getPages(FormEditor formEditor, Map<String, ArrayList<Component>> componentMap);
+	public IFormPage getPage(FormEditor formEditor, Map<String, ArrayList<Component>> componentMap);
 
 }

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IListPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IListPageProvider.java
@@ -61,7 +61,7 @@ public interface IListPageProvider {
 		} else {
 			logger.error("Extension Point " + EXTENSION_POINT_ID + " does not exist");
 		}
-		return null;
+		return listPageProviders;
 	}
 
 	/**

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IListPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IListPageProvider.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014, 2015 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Nick Stanish
+ *******************************************************************************/
+
+package org.eclipse.ice.client.widgets.providers;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.ice.client.widgets.ICEFormPage;
+import org.eclipse.ice.datastructures.ICEObject.Component;
+import org.eclipse.ice.datastructures.jaxbclassprovider.IJAXBClassProvider;
+import org.eclipse.ui.forms.editor.FormEditor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is an interface for list page providers for Form Editors in ICE that provides
+ * the set of list section pages required to draw the UI.
+ * 
+ * @author Jay Jay Billings
+ *
+ */
+public interface IListPageProvider {
+	
+	public static final String EXTENSION_POINT_ID = "org.eclipse.ice.client.widgets.listPageProvider";
+	
+	
+	/**
+	 * This is a static interface method that returns all of the currently
+	 * registered IListPageProvider.
+	 * 
+	 * @return The available providers
+	 * @throws CoreException 
+	 */
+	public static IListPageProvider[] getProviders() throws CoreException {
+		// Logger for handling event messages and other information.
+		Logger logger = LoggerFactory.getLogger(IJAXBClassProvider.class);
+		IListPageProvider[] listPageProviders = null;
+		
+		IExtensionPoint point = Platform.getExtensionRegistry().getExtensionPoint(EXTENSION_POINT_ID);
+
+		if (point != null) {
+			IConfigurationElement[] elements = point.getConfigurationElements();
+			listPageProviders = new IListPageProvider[elements.length];
+			for (int i = 0; i < elements.length; i++) {
+				listPageProviders[i] = (IListPageProvider) elements[i].createExecutableExtension("class");
+			}
+		} else {
+			logger.error("Extension Point " + EXTENSION_POINT_ID + " does not exist");
+		}
+		return null;
+	}
+
+	/**
+	 * This operation returns the name of the provider.
+	 * 
+	 * @return the name
+	 */
+	public String getName();
+
+	/**
+	 * This operation directs the provider to create and return all of its pages
+	 * based on the provided set of pages.
+	 * 
+	 * @param formEditor
+	 * @param componentMap
+	 *            This map must contain the Components in the Form organized by
+	 *            type. The type is the key and a string equal to one of "data,"
+	 *            "output," "matrix," "masterDetails", "table," "geometry,"
+	 *            "shape," "tree," "mesh," or "reactor." The value is a list
+	 *            that stores all components of that type; DataComponent,
+	 *            ResourceComponent, MatrixComponent, MasterDetailsComponent,
+	 *            TableComponent, GeometryComponent, ShapeComponent,
+	 *            TreeComponent, MeshComponent, ReactorComponent, etc. This is a
+	 *            simulated multimap.
+	 * @return the form pages created from the map
+	 */
+	public ArrayList<ICEFormPage> getPages(FormEditor formEditor, Map<String, ArrayList<Component>> componentMap);
+
+}

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IListPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IListPageProvider.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * This is an interface for list page providers for Form Editors in ICE that provides
  * the set of list section pages required to draw the UI.
  * 
- * @author Jay Jay Billings
+ * @author Nick Stanish
  *
  */
 public interface IListPageProvider {
@@ -47,7 +47,7 @@ public interface IListPageProvider {
 	 */
 	public static IListPageProvider[] getProviders() throws CoreException {
 		// Logger for handling event messages and other information.
-		Logger logger = LoggerFactory.getLogger(IJAXBClassProvider.class);
+		Logger logger = LoggerFactory.getLogger(IListPageProvider.class);
 		IListPageProvider[] listPageProviders = null;
 		
 		IExtensionPoint point = Platform.getExtensionRegistry().getExtensionPoint(EXTENSION_POINT_ID);

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IPageProvider.java
@@ -9,7 +9,7 @@
  *   Initial API and implementation and/or initial documentation - 
  *   Jay Jay Billings
  *******************************************************************************/
-package org.eclipse.ice.client.widgets;
+package org.eclipse.ice.client.widgets.providers;
 
 import java.util.ArrayList;
 import java.util.Map;


### PR DESCRIPTION
Added extension point for list page providers.
ICEFormEditor now uses IListPageProvider to find all registered
providers, and then uses the default provider to get the pages.

Also uses IErrorPageProvider and a DefaultErrorPageProvider to go with it

Signed-off-by: Nick Stanish <nickstanish@gmail.com>