### PR TITLE
Bug 481365

### DIFF
--- a/org.eclipse.ice.client.widgets/META-INF/MANIFEST.MF
+++ b/org.eclipse.ice.client.widgets/META-INF/MANIFEST.MF
@@ -14,6 +14,7 @@ Require-Bundle: org.eclipse.ice.datastructures,
  org.eclipse.swt
 Import-Package: com.jme3.app,
  org.apache.commons.io,
+ org.apache.log4j.spi;version="1.2.15",
  org.eclipse.core.commands.common,
  org.eclipse.core.expressions,
  org.eclipse.core.filesystem,

--- a/org.eclipse.ice.client.widgets/plugin.xml
+++ b/org.eclipse.ice.client.widgets/plugin.xml
@@ -5,6 +5,7 @@
    <extension-point id="org.eclipse.ice.client.widgets.iformwidgetbuilder" name="IForm Widget Builder" schema="schema/iformwidgetbuilder.exsd"/>
    <extension-point id="org.eclipse.ice.client.widgets.listPageProvider" name="List Page Provider" schema="schema/org.eclipse.ice.client.widgets.listPageProvider.exsd"/>
    <extension-point id="errorPageProvider" name="Error Page Provider" schema="schema/errorPageProvider.exsd"/>
+   <extension-point id="org.eclipse.ice.client.widgets.resourcePageProvider" name="Resource Page Provider" schema="schema/org.eclipse.ice.client.widgets.resourcePageProvider.exsd"/>
 
       <extension
          point="org.eclipse.ui.editors">
@@ -395,5 +396,13 @@
     <implementation
           class="org.eclipse.ice.client.widgets.providers.DefaultListPageProvider">
     </implementation>
+ </extension>
+ <extension
+       id="resourcePageProvider"
+       name="Default Resource Page Provider"
+       point="org.eclipse.ice.client.widgets.resourcePageProvider">
+    <Implementation
+          Class="org.eclipse.ice.client.widgets.providers.DefaultResourcePageProvider">
+    </Implementation>
  </extension>
 </plugin>

--- a/org.eclipse.ice.client.widgets/schema/org.eclipse.ice.client.widgets.resourcePageProvider.exsd
+++ b/org.eclipse.ice.client.widgets/schema/org.eclipse.ice.client.widgets.resourcePageProvider.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.ice.client.widgets" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.ice.client.widgets" id="org.eclipse.ice.client.widgets.resourcePageProvider" name="Resource Page Provider"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="Implementation"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="Implementation">
+      <complexType>
+         <attribute name="Class" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.ice.client.widgets.providers.IResourcePageProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultResourcePageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultResourcePageProvider.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014, 2015 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings
+ *******************************************************************************/
+package org.eclipse.ice.client.widgets.providers;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.eclipse.ice.datastructures.ICEObject.Component;
+import org.eclipse.ice.datastructures.form.ResourceComponent;
+import org.eclipse.ui.forms.editor.FormEditor;
+import org.eclipse.ice.client.widgets.ICEFormPage;
+import org.eclipse.ice.client.widgets.ICEResourcePage;
+
+/**
+ * This is the default implementation of IPageProvider and it is responsible for
+ * generating the default set of pages for ICEFormEditor.
+ * 
+ * @author Menghan Li
+ *
+ */
+public class DefaultResourcePageProvider implements IResourcePageProvider {
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.ice.client.widgets.IPageProvider#getPages(java.util.Map)
+	 */
+	
+	ResourceComponent resourceComponent = null;
+
+	public static final String PROVIDER_NAME = "default";
+
+	@Override
+	public String getName() {
+		return PROVIDER_NAME;
+	}
+	
+	
+	public ICEResourcePage getPage(FormEditor formEditor, Map<String, ArrayList<Component>> componentMap)  {
+		
+		ICEResourcePage resourceComponentPage = null;
+		
+
+		// Get the ResourceComponent and create the ICEOutput page. There
+		// should
+		// only be one output page.
+		if (!(componentMap.get("output").isEmpty())) {
+			resourceComponent = (ResourceComponent) (componentMap.get("output").get(0));
+			if (resourceComponent != null) {
+				// Make the page
+				 resourceComponentPage =  new ICEResourcePage(formEditor, resourceComponent.getName(),
+						resourceComponent.getName());
+				// Set the ResourceComponent
+				resourceComponentPage.setResourceComponent(resourceComponent);
+			}
+		}
+
+		return resourceComponentPage;
+	}
+
+
+
+}

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IResourcePageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IResourcePageProvider.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014, 2015 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Menghan Li
+ *******************************************************************************/
+package org.eclipse.ice.client.widgets.providers;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.ice.client.widgets.ICEFormPage;
+import org.eclipse.ice.client.widgets.ICEResourcePage;
+import org.eclipse.ice.datastructures.ICEObject.Component;
+import org.eclipse.ui.forms.editor.FormEditor;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
+/**
+ * This is an interface for page providers for Form Editors in ICE that provides
+ * the set of pages required to draw the UI.
+ * 
+ * @author Menghan Li
+ *
+ */
+public interface IResourcePageProvider {
+	public static final String EXTENSION_POINT_ID = "org.eclipse.ice.client.widgets.resourcePageProvider";
+
+	/**
+	 * This is a static interface method that returns all of the currently
+	 * registers IResourceProviders.
+	 * 
+	 * @return The available providers
+	 */
+	public static IResourcePageProvider[] getProviders() throws CoreException {
+		Logger logger = LoggerFactory.getLogger(IResourcePageProvider.class);
+		IResourcePageProvider[] resourcePageProviders = null;
+
+		IExtensionPoint point = Platform.getExtensionRegistry().getExtensionPoint(EXTENSION_POINT_ID);
+
+		if (point != null) {
+			IConfigurationElement[] elements = point.getConfigurationElements();
+			resourcePageProviders = new IResourcePageProvider[elements.length];
+			for (int i = 0; i < elements.length; i++) {
+				resourcePageProviders[i] = (IResourcePageProvider) elements[i].createExecutableExtension("class");
+			}
+		} else {
+			logger.error("Extension Point " + EXTENSION_POINT_ID + " does not exist");
+		}
+		return resourcePageProviders;
+	}
+
+	/**
+	 * This operation returns the name of the provider.
+	 * 
+	 * @return the name
+	 */
+	public String getName();
+
+	/**
+	 * This operation directs the provider to create and return all of its pages
+	 * based on the provided set of pages.
+	 * 
+	 * @param componentMap
+	 *            This map must contain the Components in the Form organized by
+	 *            type. The type is the key and a string equal to one of "data,"
+	 *            "output," "matrix," "masterDetails", "table," "geometry,"
+	 *            "shape," "tree," "mesh," or "reactor." The value is a list
+	 *            that stores all components of that type; DataComponent,
+	 *            ResourceComponent, MatrixComponent, MasterDetailsComponent,
+	 *            TableComponent, GeometryComponent, ShapeComponent,
+	 *            TreeComponent, MeshComponent, ReactorComponent, etc. This is a
+	 *            simulated multimap.
+	 * @return the form pages created from the map
+	 */
+	public ICEResourcePage getPage(FormEditor formEditor, Map<String, ArrayList<Component>> componentMap);
+
+}


### PR DESCRIPTION
Added extension point for resource page providers.
ICEFormEditor now uses IResourcePageProvider to find all registered
providers, and then uses the default provider to get the pages.

Signed-off-by: Menghan Li <menghanli723@gmail.com>