### PR TITLE
Bug 482456

### DIFF
--- a/org.eclipse.ice.client.widgets/plugin.xml
+++ b/org.eclipse.ice.client.widgets/plugin.xml
@@ -7,6 +7,7 @@
    <extension-point id="errorPageProvider" name="Error Page Provider" schema="schema/errorPageProvider.exsd"/>
    <extension-point id="org.eclipse.ice.client.widgets.resourcePageProvider" name="Resource Page Provider" schema="schema/org.eclipse.ice.client.widgets.resourcePageProvider.exsd"/>
    <extension-point id="org.eclipse.ice.client.widgets.basicComponentPageProvider" name="Basic Component Page Provider" schema="schema/org.eclipse.ice.client.widgets.basicComponentPageProvider.exsd"/>
+   <extension-point id="org.eclipse.ice.client.widgets.geometryPageProvider" name="geometryPageProvider" schema="schema/org.eclipse.ice.client.widgets.geometryPageProvider.exsd"/>
 
       <extension
          point="org.eclipse.ui.editors">
@@ -412,5 +413,11 @@
     <implementation
           class="org.eclipse.ice.client.widgets.providers.DefaultBasicComponentPageProvider">
     </implementation>
+ </extension>
+ <extension
+       point="org.eclipse.ice.client.widgets.geometryPageProvider">
+    <client
+          class="org.eclipse.ice.client.widgets.providers.DefaultGeometryPageProvider">
+    </client>
  </extension>
 </plugin>

--- a/org.eclipse.ice.client.widgets/plugin.xml
+++ b/org.eclipse.ice.client.widgets/plugin.xml
@@ -8,6 +8,7 @@
    <extension-point id="org.eclipse.ice.client.widgets.resourcePageProvider" name="Resource Page Provider" schema="schema/org.eclipse.ice.client.widgets.resourcePageProvider.exsd"/>
    <extension-point id="org.eclipse.ice.client.widgets.basicComponentPageProvider" name="Basic Component Page Provider" schema="schema/org.eclipse.ice.client.widgets.basicComponentPageProvider.exsd"/>
    <extension-point id="org.eclipse.ice.client.widgets.geometryPageProvider" name="geometryPageProvider" schema="schema/org.eclipse.ice.client.widgets.geometryPageProvider.exsd"/>
+   <extension-point id="org.eclipse.ice.client.widgets.IEMFSectionPageProvider" name="IEMFSectionPageProvider" schema="schema/org.eclipse.ice.client.widgets.IEMFSectionPageProvider.exsd"/>
 
       <extension
          point="org.eclipse.ui.editors">
@@ -418,6 +419,12 @@
        point="org.eclipse.ice.client.widgets.geometryPageProvider">
     <client
           class="org.eclipse.ice.client.widgets.providers.DefaultGeometryPageProvider">
+    </client>
+ </extension>
+ <extension
+       point="org.eclipse.ice.client.widgets.IEMFSectionPageProvider">
+    <client
+          class="org.eclipse.ice.client.widgets.providers.DefaultIEMFSectionPageProvider">
     </client>
  </extension>
 </plugin>

--- a/org.eclipse.ice.client.widgets/plugin.xml
+++ b/org.eclipse.ice.client.widgets/plugin.xml
@@ -9,6 +9,7 @@
    <extension-point id="org.eclipse.ice.client.widgets.basicComponentPageProvider" name="Basic Component Page Provider" schema="schema/org.eclipse.ice.client.widgets.basicComponentPageProvider.exsd"/>
    <extension-point id="org.eclipse.ice.client.widgets.geometryPageProvider" name="geometryPageProvider" schema="schema/org.eclipse.ice.client.widgets.geometryPageProvider.exsd"/>
    <extension-point id="org.eclipse.ice.client.widgets.IEMFSectionPageProvider" name="IEMFSectionPageProvider" schema="schema/org.eclipse.ice.client.widgets.IEMFSectionPageProvider.exsd"/>
+   <extension-point id="org.eclipse.ice.client.widgets.meshPageProvider" name="meshPageProvider" schema="schema/org.eclipse.ice.client.widgets.meshPageProvider.exsd"/>
 
       <extension
          point="org.eclipse.ui.editors">
@@ -425,6 +426,12 @@
        point="org.eclipse.ice.client.widgets.IEMFSectionPageProvider">
     <client
           class="org.eclipse.ice.client.widgets.providers.DefaultIEMFSectionPageProvider">
+    </client>
+ </extension>
+ <extension
+       point="org.eclipse.ice.client.widgets.meshPageProvider">
+    <client
+          class="org.eclipse.ice.client.widgets.providers.DefaultMeshPageProvider">
     </client>
  </extension>
 </plugin>

--- a/org.eclipse.ice.client.widgets/schema/org.eclipse.ice.client.widgets.IEMFSectionPageProvider.exsd
+++ b/org.eclipse.ice.client.widgets/schema/org.eclipse.ice.client.widgets.IEMFSectionPageProvider.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.ice.client.widgets" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.ice.client.widgets" id="org.eclipse.ice.client.widgets.IEMFSectionPageProvider" name="IEMFSectionPageProvider"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="client"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="client">
+      <complexType>
+         <attribute name="class" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.ice.client.widgets.providers.IEMFSectionPageProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.eclipse.ice.client.widgets/schema/org.eclipse.ice.client.widgets.geometryPageProvider.exsd
+++ b/org.eclipse.ice.client.widgets/schema/org.eclipse.ice.client.widgets.geometryPageProvider.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.ice.client.widgets" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.ice.client.widgets" id="org.eclipse.ice.client.widgets.geometryPageProvider" name="geometryPageProvider"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="client"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="client">
+      <complexType>
+         <attribute name="class" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.ice.client.widgets.providers.IGeometryPageProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.eclipse.ice.client.widgets/schema/org.eclipse.ice.client.widgets.meshPageProvider.exsd
+++ b/org.eclipse.ice.client.widgets/schema/org.eclipse.ice.client.widgets.meshPageProvider.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.ice.client.widgets" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.ice.client.widgets" id="org.eclipse.ice.client.widgets.meshPageProvider" name="meshPageProvider"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="client"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="client">
+      <complexType>
+         <attribute name="class" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.ice.client.widgets.providers.IMeshPageProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
@@ -442,9 +442,19 @@ public class ICEFormEditor extends SharedHeaderFormEditor
 	 * @return The MeshPage created.
 	 */
 	private ICEFormPage createMeshPage() {
-
+		ArrayList<Component> comps = new ArrayList<Component>();
+		ArrayList<ICEFormPage> pages = new ArrayList<ICEFormPage>();
+		
+		comps.addAll(componentMap.get("mesh"));
+		DefaultPageFactory defaultPageFactory = new DefaultPageFactory();
+		ArrayList<IFormPage> componentPages = defaultPageFactory.getMeshComponentPages(this, comps);
+		
+		for(IFormPage componentPage: componentPages){
+			pages.add((ICEFormPage)componentPage);
+		}
+		return pages.get(0);
 		// Need IMeshPageProvider
-
+		/*
 		// Local Declarations
 		MeshComponent meshComponent = new MeshComponent();
 
@@ -465,6 +475,7 @@ public class ICEFormEditor extends SharedHeaderFormEditor
 		}
 
 		return meshPage;
+		*/
 	}
 
 	/**

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
@@ -394,9 +394,23 @@ public class ICEFormEditor extends SharedHeaderFormEditor
 	 * @return The GeometryPage created.
 	 */
 	private ICEFormPage createGeometryPage() {
-
+		
+		
+		ArrayList<Component> comps = new ArrayList<Component>();
+		ArrayList<ICEFormPage> pages = new ArrayList<ICEFormPage>();
+		
+		comps.addAll(componentMap.get("geometry"));
+		
+		DefaultPageFactory defaultPageFactory = new DefaultPageFactory();
+		ArrayList<IFormPage> componentPages = defaultPageFactory.getGeometryComponentPages(this, comps);
+		
+		for(IFormPage componentPage: componentPages){
+			pages.add((ICEFormPage)componentPage);
+		}
+		
+		return pages.get(0);
 		// Need IGeometryPageProvider
-
+		/*
 		// Local Declarations
 		GeometryComponent geometryComponent = new GeometryComponent();
 		geometryComponent.setGeometry(new ICEGeometry());
@@ -418,7 +432,7 @@ public class ICEFormEditor extends SharedHeaderFormEditor
 
 		}
 
-		return geometryPage;
+		return geometryPage;*/
 	}
 
 	/**

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/ICEFormEditor.java
@@ -473,9 +473,24 @@ public class ICEFormEditor extends SharedHeaderFormEditor
 	 * @return The ICEFormPages for each EMF Component in the list.
 	 */
 	private ArrayList<ICEFormPage> createEMFSectionPages() {
-
+		
+		
+		ArrayList<Component> comps = new ArrayList<Component>();
+		
+		comps.addAll(componentMap.get("emf"));
+		ArrayList<ICEFormPage> pages = new ArrayList<ICEFormPage>();
+		
+		DefaultPageFactory defaultPageFactory = new DefaultPageFactory();
+		
+		ArrayList<IFormPage> componentPages = defaultPageFactory.getIEFSectionComponentPages(this, comps);
+		for(IFormPage componentPage: componentPages){
+			pages.add((ICEFormPage)componentPage);
+		}
+		
+		return pages;
+		
 		// Need IEMFSectionPageProvider
-
+		/*
 		// Local Declarations
 		EMFComponent emfComponent = null;
 		EMFSectionPage emfPage = null;
@@ -496,7 +511,7 @@ public class ICEFormEditor extends SharedHeaderFormEditor
 			}
 		}
 
-		return pages;
+		return pages;*/
 	}
 
 	/**

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultGeometryPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultGeometryPageProvider.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014, 2015 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Fangzhou Lin
+ *   Minor updates for architecture compliance - Jay Jay Billings
+ *******************************************************************************/
 package org.eclipse.ice.client.widgets.providers;
 
 import java.util.ArrayList;
@@ -8,10 +19,22 @@ import org.eclipse.ice.datastructures.form.GeometryComponent;
 import org.eclipse.ice.datastructures.form.geometry.ICEGeometry;
 import org.eclipse.ui.forms.editor.FormEditor;
 import org.eclipse.ui.forms.editor.IFormPage;
-
+/**
+ * This class is a default extension for providing Default Geometry Page
+ * 
+ * @author Fangzhou Lin, Jay Jay Billings
+ *
+ */
 
 public class DefaultGeometryPageProvider extends DefaultPageProvider 
 		implements IGeometryPageProvider {
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.eclipse.ice.client.widgets.providers.IGeometryPageProvider#getPages(org.
+	 * eclipse.ui.forms.editor.FormEditor, java.util.ArrayList)
+	 */
 	@Override
 	public ArrayList<IFormPage> getPages(FormEditor formEditor,
 			ArrayList<Component> components){

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultGeometryPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultGeometryPageProvider.java
@@ -1,0 +1,42 @@
+package org.eclipse.ice.client.widgets.providers;
+
+import java.util.ArrayList;
+
+import org.eclipse.ice.client.widgets.ICEGeometryPage;
+import org.eclipse.ice.datastructures.ICEObject.Component;
+import org.eclipse.ice.datastructures.form.GeometryComponent;
+import org.eclipse.ice.datastructures.form.geometry.ICEGeometry;
+import org.eclipse.ui.forms.editor.FormEditor;
+import org.eclipse.ui.forms.editor.IFormPage;
+
+
+public class DefaultGeometryPageProvider extends DefaultPageProvider 
+		implements IGeometryPageProvider {
+	@Override
+	public ArrayList<IFormPage> getPages(FormEditor formEditor,
+			ArrayList<Component> components){
+		ICEGeometryPage geometryPage;
+		GeometryComponent geometryComponent = new GeometryComponent();
+		geometryComponent.setGeometry(new ICEGeometry());
+		ArrayList<IFormPage> regeometryPage = new ArrayList<IFormPage>();
+		// Get the GeometryComponent and create the GeometryPage.
+		if (!(components.isEmpty())) {
+			geometryComponent = (GeometryComponent) (components
+					.get(0));
+
+			if (geometryComponent != null) {
+
+				// Make the GeometryPage
+				geometryPage = new ICEGeometryPage(formEditor, "GPid",
+						geometryComponent.getName());
+
+				// Set the GeometryComponent
+				geometryPage.setGeometry(geometryComponent);
+				regeometryPage.add(geometryPage);
+			}
+
+		}
+		
+		return regeometryPage;
+	}
+}

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultIEMFSectionPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultIEMFSectionPageProvider.java
@@ -1,0 +1,34 @@
+package org.eclipse.ice.client.widgets.providers;
+
+import java.util.ArrayList;
+
+import org.eclipse.ice.client.widgets.EMFSectionPage;
+import org.eclipse.ice.client.widgets.ICEFormPage;
+import org.eclipse.ice.datastructures.ICEObject.Component;
+import org.eclipse.ice.datastructures.form.emf.EMFComponent;
+import org.eclipse.ui.forms.editor.FormEditor;
+import org.eclipse.ui.forms.editor.IFormPage;
+
+public class DefaultIEMFSectionPageProvider extends DefaultPageProvider implements IEMFSectionPageProvider{
+	public ArrayList<IFormPage> getPages(FormEditor formEditor,
+			ArrayList<Component> components){
+		ArrayList<IFormPage> pages = new ArrayList<IFormPage>();
+		EMFComponent emfComponent = null;
+		EMFSectionPage emfPage = null;
+		if (components.size() > 0) {
+			for (Component comp : components) {
+				emfComponent = (EMFComponent) comp;
+				if (emfComponent != null) {
+					// Make the EMFSectionPage
+					emfPage = new EMFSectionPage(formEditor, emfComponent.getName(),
+							emfComponent.getName());
+					// Set the EMFComponent
+					emfPage.setEMFComponent(emfComponent);
+					pages.add(emfPage);
+				}
+			}
+		}
+		
+		return pages;
+	}
+}

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultIEMFSectionPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultIEMFSectionPageProvider.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014, 2015 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Fangzhou Lin
+ *   Minor updates for architecture compliance - Jay Jay Billings
+ *******************************************************************************/
 package org.eclipse.ice.client.widgets.providers;
 
 import java.util.ArrayList;
@@ -8,8 +19,20 @@ import org.eclipse.ice.datastructures.ICEObject.Component;
 import org.eclipse.ice.datastructures.form.emf.EMFComponent;
 import org.eclipse.ui.forms.editor.FormEditor;
 import org.eclipse.ui.forms.editor.IFormPage;
-
+/**
+ * This class is a default extension for providing Default IEMFSection Page
+ * 
+ * @author Fangzhou Lin, Jay Jay Billings
+ *
+ */
 public class DefaultIEMFSectionPageProvider extends DefaultPageProvider implements IEMFSectionPageProvider{
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.eclipse.ice.client.widgets.providers.IEMFSectionPageProvider(org.
+	 * eclipse.ui.forms.editor.FormEditor, java.util.ArrayList)
+	 */
 	public ArrayList<IFormPage> getPages(FormEditor formEditor,
 			ArrayList<Component> components){
 		ArrayList<IFormPage> pages = new ArrayList<IFormPage>();

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultMeshPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultMeshPageProvider.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014, 2015 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Fangzhou Lin
+ *   Minor updates for architecture compliance - Jay Jay Billings
+ *******************************************************************************/
 package org.eclipse.ice.client.widgets.providers;
 
 import java.util.ArrayList;
@@ -7,8 +18,20 @@ import org.eclipse.ice.datastructures.ICEObject.Component;
 import org.eclipse.ice.datastructures.form.MeshComponent;
 import org.eclipse.ui.forms.editor.FormEditor;
 import org.eclipse.ui.forms.editor.IFormPage;
-
+/**
+ * This class is a default extension for providing Default Mesh Page
+ * 
+ * @author Fangzhou Lin, Jay Jay Billings
+ *
+ */
 public class DefaultMeshPageProvider extends DefaultPageProvider implements IMeshPageProvider{
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.eclipse.ice.client.widgets.providers.IMeshPageProvider(org.
+	 * eclipse.ui.forms.editor.FormEditor, java.util.ArrayList)
+	 */
 	public ArrayList<IFormPage> getPages(FormEditor formEditor,
 			ArrayList<Component> components){
 		ArrayList<IFormPage> pages = new ArrayList<IFormPage>();

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultMeshPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultMeshPageProvider.java
@@ -1,0 +1,37 @@
+package org.eclipse.ice.client.widgets.providers;
+
+import java.util.ArrayList;
+
+import org.eclipse.ice.client.widgets.ICEMeshPage;
+import org.eclipse.ice.datastructures.ICEObject.Component;
+import org.eclipse.ice.datastructures.form.MeshComponent;
+import org.eclipse.ui.forms.editor.FormEditor;
+import org.eclipse.ui.forms.editor.IFormPage;
+
+public class DefaultMeshPageProvider extends DefaultPageProvider implements IMeshPageProvider{
+	public ArrayList<IFormPage> getPages(FormEditor formEditor,
+			ArrayList<Component> components){
+		ArrayList<IFormPage> pages = new ArrayList<IFormPage>();
+		
+		MeshComponent meshComponent = new MeshComponent();
+
+		// Get the GeometryComponent and create the GeometryPage.
+		if (!(components.isEmpty())) {
+			meshComponent = (MeshComponent) (components.get(0));
+
+			if (meshComponent != null) {
+				ICEMeshPage meshPage;
+				// Make the MeshPage
+				meshPage = new ICEMeshPage(formEditor, "MeshPid",
+						meshComponent.getName());
+
+				// Set the MeshComponent
+				meshPage.setMeshComponent(meshComponent);
+				pages.add(meshPage);
+			}
+
+		}
+
+		return pages;
+	}
+}

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultPageFactory.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultPageFactory.java
@@ -209,5 +209,32 @@ public class DefaultPageFactory implements IPageFactory {
 		
 		return pages;
 	}
+	
+	@Override
+	public ArrayList<IFormPage> getIEFSectionComponentPages(FormEditor editor,
+			ArrayList<Component> components) {
+		ArrayList<IFormPage> pages = new ArrayList<IFormPage>();
+		try{
+			ArrayList<IEMFSectionPageProvider> EFSectionComponentPages = 
+					IEMFSectionPageProvider.getProviders();
+			if (EFSectionComponentPages != null && EFSectionComponentPages.size() > 0) {
+				// Use the default error page provider
+				String providerNameToUse = DefaultErrorPageProvider.PROVIDER_NAME;
+				// Do a linear search to find the correct provider
+				for (IEMFSectionPageProvider currentProvider : EFSectionComponentPages) {
+					if (providerNameToUse.equals(currentProvider.getName())) {
+						pages = currentProvider.getPages(editor, null);
+						break;
+					}
+				}
+			}else{
+				logger.error("No EFSectionComponentPages registered");
+			}
+		}catch(CoreException e){
+			logger.error("Unable to get IEFSectionComponentPages", e);
+		}
+		return pages;
+		
+	}
 
 }

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultPageFactory.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultPageFactory.java
@@ -151,7 +151,11 @@ public class DefaultPageFactory implements IPageFactory {
 		return pages.get(0);
 	}
 	
-
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.ice.client.widgets.providers.IPageFactory#getComponentPages()
+	 */
 	@Override
 	public ArrayList<IFormPage> getComponentPages(FormEditor editor,
 			ArrayList<Component> components) {
@@ -182,6 +186,11 @@ public class DefaultPageFactory implements IPageFactory {
 		return pages;
 	}
 	
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.ice.client.widgets.providers.IPageFactory#getGeometryComponentPages()
+	 */
 	@Override
 	public ArrayList<IFormPage> getGeometryComponentPages(FormEditor editor,
 			ArrayList<Component> components) {
@@ -210,6 +219,11 @@ public class DefaultPageFactory implements IPageFactory {
 		return pages;
 	}
 	
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.ice.client.widgets.providers.IPageFactory#getIEFSectionComponentPages()
+	 */
 	@Override
 	public ArrayList<IFormPage> getIEFSectionComponentPages(FormEditor editor,
 			ArrayList<Component> components) {
@@ -237,6 +251,11 @@ public class DefaultPageFactory implements IPageFactory {
 		
 	}
 	
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.ice.client.widgets.providers.IPageFactory#getMeshComponentPages()
+	 */
 	@Override
 	public ArrayList<IFormPage> getMeshComponentPages(FormEditor editor,
 			ArrayList<Component> components){

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultPageFactory.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultPageFactory.java
@@ -181,5 +181,33 @@ public class DefaultPageFactory implements IPageFactory {
 
 		return pages;
 	}
+	
+	@Override
+	public ArrayList<IFormPage> getGeometryComponentPages(FormEditor editor,
+			ArrayList<Component> components) {
+		ArrayList<IFormPage> pages = new ArrayList<IFormPage>();
+		try{
+			ArrayList<IGeometryPageProvider> geometryComponentProviders = 
+					IGeometryPageProvider.getProviders();
+			if (geometryComponentProviders != null && geometryComponentProviders.size() > 0) {
+				// Use the default error page provider
+				String providerNameToUse = DefaultErrorPageProvider.PROVIDER_NAME;
+				// Do a linear search to find the correct provider
+				for (IGeometryPageProvider currentProvider : geometryComponentProviders) {
+					if (providerNameToUse.equals(currentProvider.getName())) {
+						pages = currentProvider.getPages(editor, null);
+						break;
+					}
+				}
+			}else{
+				logger.error("No GeometryComponentProviders registered");
+			}
+			
+		} catch (CoreException e){
+			logger.error("Unable to get GeometryComponentPageProviders", e);
+		}
+		
+		return pages;
+	}
 
 }

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultPageFactory.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/DefaultPageFactory.java
@@ -236,5 +236,31 @@ public class DefaultPageFactory implements IPageFactory {
 		return pages;
 		
 	}
+	
+	@Override
+	public ArrayList<IFormPage> getMeshComponentPages(FormEditor editor,
+			ArrayList<Component> components){
+		ArrayList<IFormPage> pages = new ArrayList<IFormPage>();
+		try{
+			ArrayList<IMeshPageProvider> MeshComponentPages = 
+					IMeshPageProvider.getProviders();
+			if (MeshComponentPages != null && MeshComponentPages.size() > 0) {
+				// Use the default error page provider
+				String providerNameToUse = DefaultErrorPageProvider.PROVIDER_NAME;
+				// Do a linear search to find the correct provider
+				for (IMeshPageProvider currentProvider : MeshComponentPages) {
+					if (providerNameToUse.equals(currentProvider.getName())) {
+						pages = currentProvider.getPages(editor, null);
+						break;
+					}
+				}
+			}else{
+				logger.error("No MeshComponentPages registered");
+			}
+		}catch(CoreException e){
+			logger.error("Unable to get MeshComponentPages", e);
+		}
+		return pages;
+	}
 
 }

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IEMFSectionPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IEMFSectionPageProvider.java
@@ -1,0 +1,15 @@
+package org.eclipse.ice.client.widgets.providers;
+
+import java.util.ArrayList;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ice.client.common.ExtensionHelper;
+
+public interface IEMFSectionPageProvider extends IPageProvider {
+	public static final String EXTENSION_POINT_ID = "org.eclipse.ice.client.widgets.IEMFSectionPageProvider";
+	public static ArrayList<IEMFSectionPageProvider> getProviders() throws CoreException {
+		ExtensionHelper<IEMFSectionPageProvider> extensionHelper = new ExtensionHelper<IEMFSectionPageProvider>();
+		return extensionHelper.getExtensions(EXTENSION_POINT_ID);
+		
+	}
+}

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IEMFSectionPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IEMFSectionPageProvider.java
@@ -1,12 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014, 2015 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Fangzhou Lin
+ *******************************************************************************/
 package org.eclipse.ice.client.widgets.providers;
 
 import java.util.ArrayList;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ice.client.common.ExtensionHelper;
-
+/**
+ * This is an interface for IEMFSection page providers for Form Editors in ICE that
+ * provides the set of list section pages required to draw the UI.
+ * 
+ * @author Fangzhou Lin, Jay Jay Billings
+ **/
 public interface IEMFSectionPageProvider extends IPageProvider {
+	/**
+	 * Extension point ID for IEMFSectionPageProviders.
+	 */
 	public static final String EXTENSION_POINT_ID = "org.eclipse.ice.client.widgets.IEMFSectionPageProvider";
+	
+	/**
+	 * This is a static interface method that returns all of the currently
+	 * registered IEMFSectionPageProvider.
+	 * 
+	 * @return The available providers
+	 * @throws CoreException
+	 */
 	public static ArrayList<IEMFSectionPageProvider> getProviders() throws CoreException {
 		ExtensionHelper<IEMFSectionPageProvider> extensionHelper = new ExtensionHelper<IEMFSectionPageProvider>();
 		return extensionHelper.getExtensions(EXTENSION_POINT_ID);

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IGeometryPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IGeometryPageProvider.java
@@ -1,0 +1,14 @@
+package org.eclipse.ice.client.widgets.providers;
+
+import java.util.ArrayList;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ice.client.common.ExtensionHelper;
+
+public interface  IGeometryPageProvider extends IPageProvider {
+	public static final String EXTENSION_POINT_ID = "org.eclipse.ice.client.widgets.geometryPageProvider";
+	public static ArrayList<IGeometryPageProvider> getProviders() throws CoreException {
+		ExtensionHelper<IGeometryPageProvider> extensionHelper = new ExtensionHelper<IGeometryPageProvider>();
+		return extensionHelper.getExtensions(EXTENSION_POINT_ID);
+	}
+}

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IGeometryPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IGeometryPageProvider.java
@@ -1,12 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014, 2015 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Fangzhou Lin
+ *******************************************************************************/
+
 package org.eclipse.ice.client.widgets.providers;
 
 import java.util.ArrayList;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ice.client.common.ExtensionHelper;
-
+/**
+ * This is an interface for IGeometry page providers for Form Editors in ICE that
+ * provides the set of list section pages required to draw the UI.
+ * 
+ * @author Fangzhou Lin, Jay Jay Billings
+ **/
 public interface  IGeometryPageProvider extends IPageProvider {
+	/**
+	 * Extension point ID for IGeometryPageProviders.
+	 */
 	public static final String EXTENSION_POINT_ID = "org.eclipse.ice.client.widgets.geometryPageProvider";
+	
+	/**
+	 * This is a static interface method that returns all of the currently
+	 * registered IGeometryPageProvider.
+	 * 
+	 * @return The available providers
+	 * @throws CoreException
+	 */
 	public static ArrayList<IGeometryPageProvider> getProviders() throws CoreException {
 		ExtensionHelper<IGeometryPageProvider> extensionHelper = new ExtensionHelper<IGeometryPageProvider>();
 		return extensionHelper.getExtensions(EXTENSION_POINT_ID);

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IMeshPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IMeshPageProvider.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2014, 2015 UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Fangzhou Lin
+ *******************************************************************************/
 package org.eclipse.ice.client.widgets.providers;
 
 import java.util.ArrayList;
@@ -5,8 +16,26 @@ import java.util.ArrayList;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ice.client.common.ExtensionHelper;
 
+/**
+ * This is an interface for IMesh page providers for Form Editors in ICE that
+ * provides the set of list section pages required to draw the UI.
+ * 
+ * @author Fangzhou Lin, Jay Jay Billings
+ *
+ */
 public interface IMeshPageProvider extends IPageProvider{
+	/**
+	 * Extension point ID for IMeshPageProviders.
+	 */
 	public static final String EXTENSION_POINT_ID = "org.eclipse.ice.client.widgets.meshPageProvider";
+	
+	/**
+	 * This is a static interface method that returns all of the currently
+	 * registered IMeshPageProvider.
+	 * 
+	 * @return The available providers
+	 * @throws CoreException
+	 */
 	public static ArrayList<IMeshPageProvider> getProviders() throws CoreException {
 		ExtensionHelper<IMeshPageProvider> extensionHelper = new ExtensionHelper<IMeshPageProvider>();
 		return extensionHelper.getExtensions(EXTENSION_POINT_ID);

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IMeshPageProvider.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IMeshPageProvider.java
@@ -1,0 +1,14 @@
+package org.eclipse.ice.client.widgets.providers;
+
+import java.util.ArrayList;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ice.client.common.ExtensionHelper;
+
+public interface IMeshPageProvider extends IPageProvider{
+	public static final String EXTENSION_POINT_ID = "org.eclipse.ice.client.widgets.meshPageProvider";
+	public static ArrayList<IMeshPageProvider> getProviders() throws CoreException {
+		ExtensionHelper<IMeshPageProvider> extensionHelper = new ExtensionHelper<IMeshPageProvider>();
+		return extensionHelper.getExtensions(EXTENSION_POINT_ID);
+	}
+}

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IPageFactory.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IPageFactory.java
@@ -82,4 +82,7 @@ public interface IPageFactory {
 	
 	public ArrayList<IFormPage> getIEFSectionComponentPages(FormEditor editor,
 			ArrayList<Component> components);
+	
+	public ArrayList<IFormPage> getMeshComponentPages(FormEditor editor,
+			ArrayList<Component> components);
 }

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IPageFactory.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IPageFactory.java
@@ -77,12 +77,45 @@ public interface IPageFactory {
 	public ArrayList<IFormPage> getComponentPages(FormEditor editor,
 			ArrayList<Component> components);
 	
+	/**
+	 * This operation returns the rendered pages that will display the contents
+	 * of the getGeometry components.
+	 *
+	 * @param editor
+	 *            the form editor where the pages will reside
+	 * @param components
+	 *            the list components whose contents should be rendered
+	 * @return the form pages on which the contents of the lists have been
+	 *         rendered
+	 */
 	public ArrayList<IFormPage> getGeometryComponentPages(FormEditor editor,
 			ArrayList<Component> components);
 	
+	/**
+	 * This operation returns the rendered pages that will display the contents
+	 * of the IEFSection components.
+	 *
+	 * @param editor
+	 *            the form editor where the pages will reside
+	 * @param components
+	 *            the list components whose contents should be rendered
+	 * @return the form pages on which the contents of the lists have been
+	 *         rendered
+	 */
 	public ArrayList<IFormPage> getIEFSectionComponentPages(FormEditor editor,
 			ArrayList<Component> components);
 	
+	/**
+	 * This operation returns the rendered pages that will display the contents
+	 * of the Mesh components.
+	 *
+	 * @param editor
+	 *            the form editor where the pages will reside
+	 * @param components
+	 *            the list components whose contents should be rendered
+	 * @return the form pages on which the contents of the lists have been
+	 *         rendered
+	 */
 	public ArrayList<IFormPage> getMeshComponentPages(FormEditor editor,
 			ArrayList<Component> components);
 }

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IPageFactory.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IPageFactory.java
@@ -76,5 +76,8 @@ public interface IPageFactory {
 	 */
 	public ArrayList<IFormPage> getComponentPages(FormEditor editor,
 			ArrayList<Component> components);
+	
+	public ArrayList<IFormPage> getGeometryComponentPages(FormEditor editor,
+			ArrayList<Component> components);
 
 }

--- a/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IPageFactory.java
+++ b/org.eclipse.ice.client.widgets/src/org/eclipse/ice/client/widgets/providers/IPageFactory.java
@@ -79,5 +79,7 @@ public interface IPageFactory {
 	
 	public ArrayList<IFormPage> getGeometryComponentPages(FormEditor editor,
 			ArrayList<Component> components);
-
+	
+	public ArrayList<IFormPage> getIEFSectionComponentPages(FormEditor editor,
+			ArrayList<Component> components);
 }


### PR DESCRIPTION
Added extension point for Geometry page providers.
ICEFormEditor now uses IGeometryPageProvide to find all registered
providers, and then uses the default provider to get the pages.

Signed-off-by: Fangzhou Lin <adamlangwang@gmail.com>