### PR TITLE
Add shebang so that ICE installer can be executed directly

### DIFF
--- a/org.eclipse.ice.installer/Install_ICE.py
+++ b/org.eclipse.ice.installer/Install_ICE.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # ******************************************************************************
-# Copyright (c) 2015 UT-Battelle, LLC.
+# Copyright (c) 2015, 2016 UT-Battelle, LLC. and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at


### PR DESCRIPTION
Without the shebang, on Linux this happens:
$ ./Install_ICE.py
from: can't read /var/mail/__future__

Signed-off-by: Jonah Graham <jonah@kichwacoders.com>