### PR TITLE
Initial Commands API 

### DIFF
--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
@@ -11,6 +11,9 @@
  *   Joe Osborn
  *******************************************************************************/
 package org.eclipse.ice.commands;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
 
 /**
  * This class is the instantiation class of the CommandFactory class and thus
@@ -18,14 +21,29 @@ package org.eclipse.ice.commands;
  * @author Joe Osborn
  *
  */
-public class Command{
+public abstract class Command{
 
+	/**
+	 * An atomic boolean for notifying the thread that it should proceed launching
+	 * the job since the form has been submitted.
+	 */
+	private AtomicBoolean formSubmitted;
+	
+	/**
+	 * The current status of the command
+	 */
+	protected CommandStatus status;
+	
+	/**
+	 * The configuration parameters of the command - should contain some information about
+	 * what the command is actually intended to do.
+	 */
+	protected CommandConfiguration configuration;
+	
 	/**
 	 * Default constructor
 	 */
-	public Command() {
-		
-	}
+	public Command() {}
 	
 	/**
 	 * 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
@@ -1,0 +1,46 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.commands;
+
+/**
+ * This class is the instantiation class of the CommandFactory class and thus
+ * is responsible for executing particular commands.
+ * @author Joe Osborn
+ *
+ */
+public class Command{
+
+	/**
+	 * Default constructor
+	 */
+	public Command() {
+		
+	}
+	
+	/**
+	 * 
+	 * @param command - Command to be executed
+	 * @return CommandStatus - indicating whether or not the Command was properly executed
+	 */
+	public CommandStatus execute(String command) {
+		return null;
+	}
+	
+	/**
+	 * 
+	 * @return - return current status for a particular command
+	 */
+	public CommandStatus GetStatus() {
+		return null;
+	}
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
@@ -32,7 +32,7 @@ public class Command{
 	 * @param command - Command to be executed
 	 * @return CommandStatus - indicating whether or not the Command was properly executed
 	 */
-	public CommandStatus execute(String command) {
+	public CommandStatus Execute(String command) {
 		return null;
 	}
 	

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandConfiguration.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+ 
+package org.eclipse.ice.commands;
+
+/**
+ * 
+ * This class configures particular commands to be executed and depends on the Command class.
+ * @author Joe Osborn
+ *
+ */
+public class CommandConfiguration {
+
+	/**
+	 * Default constructor
+	 */
+	public CommandConfiguration() {
+	}
+
+	
+	
+	
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandConfiguration.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandConfiguration.java
@@ -13,6 +13,10 @@
  
 package org.eclipse.ice.commands;
 
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * 
  * This class configures particular commands to be executed and depends on the Command class.
@@ -21,6 +25,36 @@ package org.eclipse.ice.commands;
  */
 public class CommandConfiguration {
 
+	/**
+	 * An integer ID to associate with a job
+	 */
+	private int commandId;
+	
+	/**
+	 * An AtomicBoolean that is true if the job is to be launched locally and false otherwise.
+	 */
+	private AtomicBoolean isLocal;
+	
+	/**
+	 * The dictionary that contains the command properties.
+	 */
+	private Dictionary<String,String> execDictionary;
+	
+	/**
+	 * A flag to mark whether or not the input file name should be appended to the executable command.
+	 * Marked as true by default so that the user (by default) specifies the input file name.
+	 */
+	private boolean appendInput = true;
+	
+	
+	/**
+	 * The full command string of all stages that will be executed.
+	 */
+	private String fullCommand = "";
+	
+	private ArrayList<String> splitCommand = new ArrayList<String>();
+	
+	
 	/**
 	 * Default constructor
 	 */

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandStatus.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandStatus.java
@@ -1,0 +1,43 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.commands;
+
+/**
+ * This class provides a status for commands, in particular in relation to whether 
+ * or not a particular command executed properly (or not).
+ * @author Joe Osborn
+ *
+ */
+
+
+/**
+ * 
+ * Enumeration indicating what the status of the particular command was
+ */
+enum Status{
+	SUCCESS, WORKING, FAILED;
+}
+
+public class CommandStatus{
+
+	/**
+	 * Default constructor
+	 */
+	
+	public CommandStatus() {
+		
+	}
+	 
+	
+
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandStatus.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandStatus.java
@@ -22,7 +22,7 @@ package org.eclipse.ice.commands;
 
 /**
  * 
- * Enumeration indicating what the status of the particular command was
+ * Enumeration indicating what the status of the particular command was.
  */
 enum Status{
 	SUCCESS, WORKING, FAILED;

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Connection.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Connection.java
@@ -21,6 +21,11 @@ package org.eclipse.ice.commands;
 public class Connection {
 
 	/**
+	 * The particular configuration for a particular connection
+	 */
+	ConnectionConfiguration configuration;
+	
+	/**
 	 *  Default constructor
 	 */
 	

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Connection.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Connection.java
@@ -12,32 +12,20 @@
 package org.eclipse.ice.commands;
 
 /**
- * The command factory simplifies the creation of Commands without revealing how
- * they are constructed. It is primarily used for creating generic commands,
- * whereas other factories are use for creating specific commands such as file
- * transfer commands.
+ * This class represents a connection to a remote system. This could be a system
+ * that is physically remote or remote in a process sense.
  * 
  * @author Jay Jay Billings
+ *
  */
-public class CommandFactory {
+public class Connection {
 
 	/**
-	 * Constructor
+	 * 
 	 */
-	public CommandFactory() {
+	
+	public Connection() {
 		// TODO Auto-generated constructor stub
-	}
-
-	/**
-	 * Method which gets a command and subsequently executes it on a host
-	 * See also Command class {@link org.eclipse.ice.commands.Command}.
-	 * @param command - command to execute
-	 * @param host - host on which to execute command
-	 * @return Command
-	 */
-	public static Command GetCommand(String command, String host) {
-
-		return null;
 	}
 
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Connection.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Connection.java
@@ -21,11 +21,11 @@ package org.eclipse.ice.commands;
 public class Connection {
 
 	/**
-	 * 
+	 *  Default constructor
 	 */
 	
 	public Connection() {
-		// TODO Auto-generated constructor stub
+		
 	}
 
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionConfiguration.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionConfiguration.java
@@ -12,32 +12,19 @@
 package org.eclipse.ice.commands;
 
 /**
- * The command factory simplifies the creation of Commands without revealing how
- * they are constructed. It is primarily used for creating generic commands,
- * whereas other factories are use for creating specific commands such as file
- * transfer commands.
+ * This class provides the complete configuration for a remote
+ * {@link org.eclipse.ice.commands.Connection}.
  * 
  * @author Jay Jay Billings
+ *
  */
-public class CommandFactory {
+public class ConnectionConfiguration {
 
 	/**
-	 * Constructor
+	 * 
 	 */
-	public CommandFactory() {
+	public ConnectionConfiguration() {
 		// TODO Auto-generated constructor stub
-	}
-
-	/**
-	 * Method which gets a command and subsequently executes it on a host
-	 * See also Command class {@link org.eclipse.ice.commands.Command}.
-	 * @param command - command to execute
-	 * @param host - host on which to execute command
-	 * @return Command
-	 */
-	public static Command GetCommand(String command, String host) {
-
-		return null;
 	}
 
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionConfiguration.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionConfiguration.java
@@ -21,6 +21,17 @@ package org.eclipse.ice.commands;
 public class ConnectionConfiguration {
 
 	/**
+	 * Username to configure a particular connection
+	 */
+	private String username;
+	
+	/**
+	 * Password to configure a particular connection
+	 */
+	private String password;
+	
+	
+	/**
 	 * Default constructor
 	 */
 	public ConnectionConfiguration() {

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionConfiguration.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionConfiguration.java
@@ -21,10 +21,10 @@ package org.eclipse.ice.commands;
 public class ConnectionConfiguration {
 
 	/**
-	 * 
+	 * Default constructor
 	 */
 	public ConnectionConfiguration() {
-		// TODO Auto-generated constructor stub
+		
 	}
 
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManager.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManager.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.commands;
+
+/**
+ * This class manages remote connections, and as such interfaces with all classes
+ * that are associated with remote connections.
+ * @author Joe Osborn
+ *
+ */
+public class ConnectionManager {
+
+	/**
+	 * Default Constructor
+	 */
+	public ConnectionManager() {
+		
+	}
+	
+	/**
+	 * Opens, and thus begins, a connection to either a remote system or process
+	 * @param connection - connection to be opened
+	 * @return Connection - returns connection
+	 */
+	public Connection OpenConnection(String connection) {
+		return null;
+	}
+
+	/**
+	 * Gets the connection from an already opened connection.
+	 * @param connection - connection to be returned having already been instantiated
+	 * @return Connection - returns connection asked for
+	 */
+	public static Connection GetConnection(String connection) {
+		return null;
+	}
+	
+	/**
+	 * Closes a particular connection as specified
+	 * @param connection - Connection to be closed
+	 * @return boolean - returns true if connection was successfully closed, otherwise false
+	 */
+	public boolean CloseConnection(Connection connection) {
+		
+		return false;
+	}
+	
+	/**
+	 * Closes all connections that remain open.
+	 * @return - true if successfully closed all connections, otherwise false
+	 */
+	public boolean CloseAllConnections() {
+		return false;
+	}
+	
+	
+	
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManager.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManager.java
@@ -10,6 +10,7 @@
  *   Jay Jay Billings, Joe Osborn
  *******************************************************************************/
 package org.eclipse.ice.commands;
+import java.util.ArrayList;
 
 /**
  * This factory class manages remote connections, and as such interfaces with all classes
@@ -19,6 +20,14 @@ package org.eclipse.ice.commands;
  */
 public class ConnectionManager {
 
+	
+	/**
+	 * An ArrayList of available Connections to the ConnectionManager
+	 */
+	protected ArrayList<Connection> connectionList = new ArrayList<Connection>();
+	
+	
+	
 	/**
 	 * Default Constructor
 	 */

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManager.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManager.java
@@ -12,7 +12,7 @@
 package org.eclipse.ice.commands;
 
 /**
- * This class manages remote connections, and as such interfaces with all classes
+ * This factory class manages remote connections, and as such interfaces with all classes
  * that are associated with remote connections.
  * @author Joe Osborn
  *
@@ -31,7 +31,7 @@ public class ConnectionManager {
 	 * @param connection - connection to be opened
 	 * @return Connection - returns connection
 	 */
-	public Connection OpenConnection(String connection) {
+	public static Connection OpenConnection(String connection) {
 		return null;
 	}
 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CopyFileCommand.java
@@ -1,0 +1,28 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+
+/**
+ * Parent class for remote and local copy file commands
+ * @author Joe Osborn
+ *
+ */
+public class CopyFileCommand extends FileHandler {
+
+	/**
+	 * Default constructor
+	 */
+	public CopyFileCommand() {
+		
+	}
+	
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CopyFileCommand.java
@@ -10,9 +10,10 @@
  *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
  *   Joe Osborn
  *******************************************************************************/
-
+package org.eclipse.ice.commands;
 /**
- * Parent class for remote and local copy file commands
+ * Parent class for remote and local copy file commands. Inherits
+ * from FileHandler and is responsible for executing copy file commands.
  * @author Joe Osborn
  *
  */

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.commands;
+
+import java.io.IOException;
+
+/**
+ * The FileHandler class is a utility class for using commands that move files.
+ * The class uses source and destination designations to identify how files
+ * should be handled, and it can handle both local and remote files as sources
+ * and destinations. Files can be moved, copied or checked for existence.
+ * 
+ * @author Jay Jay Billings
+ *
+ */
+public class FileHandler {
+
+	/**
+	 * Constructor
+	 */
+	public FileHandler() {
+		// TODO Auto-generated constructor stub
+	}
+
+	/**
+	 * This operations moves files from the source (src) to the destination
+	 * (dest). If the operation fails, an IOException will be thrown.
+	 * 
+	 * @param src
+	 * @param dest
+	 * @throws IOException
+	 */
+	public void move(final String src, final String dest) throws IOException {
+
+	}
+
+	/**
+	 * This operations copies files from the source (src) to the destination
+	 * (dest). If the operation fails, an IOException will be thrown.
+	 * 
+	 * @param src
+	 * @param dest
+	 * @throws IOException
+	 */
+	public void copy(final String src, final String dest) throws IOException {
+
+	}
+
+	/**
+	 * This operations determines whether or not the file argument exists.
+	 * 
+	 * @param file the file for which to search
+	 * @return true if the file exists, false if not
+	 * @throws IOException
+	 */
+	public boolean exists(final String file) throws IOException {
+		return false;
+	}
+
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
@@ -1,0 +1,30 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.commands;
+
+/**
+ * This class inherits from Command and gives available functionality for local commands.
+ * @author Joe Osborn
+ *
+ */
+public class LocalCommand extends Command{
+
+	/**
+	 * Default constructor
+	 */
+	public LocalCommand() {
+		
+	}
+
+	
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
@@ -1,0 +1,28 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+
+/**
+ * Child class for locally copying a file without a remote connection
+ * @author Joe Osborn
+ *
+ */
+public class LocalCopyFileCommand extends CopyFileCommand {
+
+	/**
+	 * Default constructor
+	 */
+	public LocalCopyFileCommand() {
+		
+	}
+	
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
@@ -11,6 +11,7 @@
  *   Joe Osborn
  *******************************************************************************/
 
+package org.eclipse.ice.commands;
 /**
  * Child class for locally copying a file without a remote connection
  * @author Joe Osborn

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
@@ -11,6 +11,7 @@
  *   Joe Osborn
  *******************************************************************************/
 
+package org.eclipse.ice.commands;
 /**
  * Child class for moving a file locally without a remote connection
  * @author Joe Osborn

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
@@ -1,0 +1,28 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+
+/**
+ * Child class for moving a file locally without a remote connection
+ * @author Joe Osborn
+ *
+ */
+public class LocalMoveFileCommand extends MoveFileCommand {
+
+	/**
+	 * Default constructor
+	 */
+	public LocalMoveFileCommand() {
+		
+	}
+	
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/MoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/MoveFileCommand.java
@@ -11,8 +11,9 @@
  *   Joe Osborn
  *******************************************************************************/
 
+package org.eclipse.ice.commands;
 /**
- * Parent class for remote and local move file commands
+ * Parent class for remote and local move file commands. 
  * @author Joe Osborn
  *
  */

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/MoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/MoveFileCommand.java
@@ -1,0 +1,28 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+
+/**
+ * Parent class for remote and local move file commands
+ * @author Joe Osborn
+ *
+ */
+public class MoveFileCommand extends FileHandler {
+
+	/**
+	 * Default constructor
+	 */
+	public MoveFileCommand() {
+		
+	}
+	
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
@@ -20,6 +20,14 @@ package org.eclipse.ice.commands;
  */
 public class RemoteCommand extends Command{
 
+	
+	/**
+	 * The particular connection associated to a particular RemoteCommand.
+	 * Declare this up front since by definition a RemoteCommand must have a connection.
+	 */
+	Connection connection = new Connection();
+	
+	
 	/**
 	 * Default constructor
 	 */
@@ -27,13 +35,21 @@ public class RemoteCommand extends Command{
 		
 	}
 	
+	/**
+	 * Set a particular connection for a particular RemoteCommand
+	 * @param connection - the connection for this command
+	 */
 	public void SetConnection(String connection) {
 		
 	}
 	
-	public String GetConnection() {
+	/**
+	 * Return the connection associated to this RemoteCommand
+	 * @return - the connection for this command
+	 */
+	public Connection GetConnection() {
 		
-		return null;
+		return connection;
 	}
 
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
@@ -13,7 +13,8 @@
 package org.eclipse.ice.commands;
 
 /**
- * This class inherits from Command and gives available functionality for remote (ssh) commands.
+ * This class inherits from Command and gives available functionality for remote commands.
+ * These could be ssh connections or a remote process.
  * @author Joe Osborn
  *
  */

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
@@ -1,0 +1,38 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.commands;
+
+/**
+ * This class inherits from Command and gives available functionality for remote (ssh) commands.
+ * @author Joe Osborn
+ *
+ */
+public class RemoteCommand extends Command{
+
+	/**
+	 * Default constructor
+	 */
+	public RemoteCommand() {
+		
+	}
+	
+	public void SetConnection(String connection) {
+		
+	}
+	
+	public String GetConnection() {
+		
+		return null;
+	}
+
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCopyFileCommand.java
@@ -11,8 +11,9 @@
  *   Joe Osborn
  *******************************************************************************/
 
+package org.eclipse.ice.commands;
 /**
- * Child class for copying a file remotely over some connection
+ * Child class for copying a file remotely over some connection. 
  * @author Joe Osborn
  *
  */

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCopyFileCommand.java
@@ -1,0 +1,28 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+
+/**
+ * Child class for copying a file remotely over some connection
+ * @author Joe Osborn
+ *
+ */
+public class RemoteCopyFileCommand extends CopyFileCommand {
+
+	/**
+	 * Default constructor
+	 */
+	public RemoteCopyFileCommand() {
+		
+	}
+	
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteMoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteMoveFileCommand.java
@@ -1,0 +1,28 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+
+/**
+ * Child class for remotely moving a file over some connection
+ * @author Joe Osborn
+ *
+ */
+public class RemoteMoveFileCommand extends MoveFileCommand {
+
+	/**
+	 * Default constructor
+	 */
+	public RemoteMoveFileCommand() {
+		
+	}
+	
+}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteMoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteMoveFileCommand.java
@@ -11,6 +11,7 @@
  *   Joe Osborn
  *******************************************************************************/
 
+package org.eclipse.ice.commands;
 /**
  * Child class for remotely moving a file over some connection
  * @author Joe Osborn

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandConfigurationTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandConfigurationTest.java
@@ -12,7 +12,7 @@
 package org.eclipse.ice.tests.commands;
 
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import org.junit.After;
 import org.junit.AfterClass;

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandConfigurationTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandConfigurationTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.tests.commands;
+
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * This class tests {@link org.eclipse.ice.commands.CommandConfiguration}.
+ * 
+ * @author Joe Osborn
+ *
+ */
+public class CommandConfigurationTest {
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	/**
+	 * Test method for {@link org.eclipse.ice.commands.CommandConfiguration#CommandConfiguration()}.
+	 */
+	@Test
+	public void testCommandConfiguration() {
+		fail("Not yet implemented");
+	}
+
+}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandStatusTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandStatusTest.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.ice.tests.commands;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -21,7 +21,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * This class tests {@link org.eclipse.ice.commands.CommandStatusTest}.
+ * This class tests {@link org.eclipse.ice.commands.CommandStatus}.
  * @author Joe Osborn
  *
  */

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandStatusTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandStatusTest.java
@@ -1,0 +1,66 @@
+/**
+ * /*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
+ *   Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.tests.commands;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * This class tests {@link org.eclipse.ice.commands.CommandStatusTest}.
+ * @author Joe Osborn
+ *
+ */
+public class CommandStatusTest {
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	/**
+	 * Test method for {@link org.eclipse.ice.commands.CommandStatus#CommandStatus()}.
+	 */
+	@Test
+	public void testCommandStatus() {
+		fail("Not yet implemented");
+	}
+
+}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.tests.commands;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * This class tests {@link org.eclipse.ice.commands.CommandTest}.
+ * 
+ * @author Joe Osborn
+ *
+ */
+public class CommandTest {
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	/**
+	 * Test method for {@link org.eclipse.ice.commands.Command#Command()}.
+	 */
+	@Test
+	public void testCommand() {
+		fail("Not yet implemented");
+	}
+
+}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionConfigurationTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionConfigurationTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.tests.commands;
+
+import static org.junit.Assert.fail;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * This class tests {@link org.eclipse.ice.commands.ConnectionConfiguration}.
+ * 
+ * @author Jay Jay Billings
+ *
+ */
+public class ConnectionConfigurationTest {
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+	}
+
+	/**
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.ConnectionConfiguration#ConnectionConfiguration()}.
+	 */
+	@Test
+	public void testConnectionConfiguration() {
+		fail("Not yet implemented");
+	}
+
+}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionManagerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionManagerTest.java
@@ -1,5 +1,4 @@
-/**
- * /*******************************************************************************
+/*******************************************************************************
  * Copyright (c) 2019- UT-Battelle, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -7,8 +6,8 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
- *   Joe Osborn
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
  *******************************************************************************/
 package org.eclipse.ice.tests.commands;
 
@@ -21,11 +20,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test for class {@link org.eclipse.ice.commands.Command}.
+ * Test for class {@link org.eclipse.ice.commands.ConnectionManager}.
  * @author Joe Osborn
  *
  */
-public class CommandTest {
+public class ConnectionManagerTest {
 
 	/**
 	 * @throws java.lang.Exception
@@ -59,29 +58,41 @@ public class CommandTest {
 	public void test() {
 		fail("Not yet implemented");
 	}
-	
-	
+
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.Command#Command()}
+	 * Test method for {@link org.eclipse.ice.commands.ConnectionManager#ConnectionManager()}
 	 */
-	public void testCommand() {
+	public void testConnectionManager() {
 		fail("Not yet implemented");
 	}
 	
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.Command#execute(String)}
+	 * Test method for {@link org.eclipse.ice.commands.ConnectionManager#OpenConnection(String)}
 	 */
-	public void testExecute() {
+	public void testOpenConnection() {
+		fail("Not yet implemented");
+	}
+	
+	
+	/**
+	 * Test method for {@link org.eclipse.ice.commands.ConnectionManager#GetConnection(String)}
+	 */
+	public void testGetConnection() {
+		fail("Not yet implemented");
+	}
+	
+	
+	/**
+	 * Test method for {@link org.eclipse.ice.commands.ConnectionManager#CloseConnection(String)}
+	 */
+	public void testCloseConnection() {
 		fail("Not yet implemented");
 	}
 	
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.Command#GetStatus()}
+	 * Test method for {@link org.eclipse.ice.commands.ConnectionManager#CloseAllConnections()}
 	 */
-	public void testGetStatus() {
+	public void testCloseAllConnection() {
 		fail("Not yet implemented");
 	}
-	
-	
-	
 }

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionTest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.tests.commands;
+
+import static org.junit.Assert.fail;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * This class tests {@link org.eclipse.ice.commands.Connection}.
+ * 
+ * @author Jay Jay Billings
+ *
+ */
+public class ConnectionTest {
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+	}
+
+	/**
+	 * Test method for {@link org.eclipse.ice.commands.Connection#Connection()}.
+	 */
+	@Test
+	public void testConnection() {
+		fail("Not yet implemented");
+	}
+
+}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CopyFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CopyFileCommandTest.java
@@ -13,16 +13,18 @@ package org.eclipse.ice.tests.commands;
 
 import static org.junit.Assert.fail;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * This class tests {@link org.eclipse.ice.commands.CommandFactory}.
- * 
- * @author Jay Jay Billings
+ * Test for class {@link org.eclipse.ice.commands.CopyFileCommand}.
+ * @author Joe Osborn
  *
  */
-public class CommandFactoryTest {
+public class CopyFileCommandTest {
 
 	/**
 	 * @throws java.lang.Exception
@@ -32,19 +34,36 @@ public class CommandFactoryTest {
 	}
 
 	/**
-	 * Test method for
-	 * {@link org.eclipse.ice.commands.CommandFactory#CommandFactory()}.
+	 * @throws java.lang.Exception
 	 */
-	@Test
-	public void testCommandFactory() {
-		fail("Not yet implemented");
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#get()}.
+	 * @throws java.lang.Exception
 	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
 	@Test
-	public void testGetCommand() {
+	public void test() {
+		fail("Not yet implemented");
+	}
+	
+	/**
+	 * Test method for{@link org.eclipse.ice.commands.CopyFileCommand()}
+	 */
+	
+	public void testCopyFileCommand() {
 		fail("Not yet implemented");
 	}
 

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/FileHandlerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/FileHandlerTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2019- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
+ *******************************************************************************/
+package org.eclipse.ice.tests.commands;
+
+import static org.junit.Assert.*;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * This class tests {@link org.eclipse.ice.commands.FileHandler}.
+ * @author Jay Jay Billings
+ *
+ */
+public class FileHandlerTest {
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+	}
+
+	/**
+	 * Test method for {@link org.eclipse.ice.commands.FileHandler#FileHandler()}.
+	 */
+	@Test
+	public void testFileHandler() {
+		fail("Not yet implemented");
+	}
+
+	/**
+	 * Test method for {@link org.eclipse.ice.commands.FileHandler#move(java.lang.String, java.lang.String)}.
+	 */
+	@Test
+	public void testMove() {
+		fail("Not yet implemented");
+	}
+
+	/**
+	 * Test method for {@link org.eclipse.ice.commands.FileHandler#copy(java.lang.String, java.lang.String)}.
+	 */
+	@Test
+	public void testCopy() {
+		fail("Not yet implemented");
+	}
+
+	/**
+	 * Test method for {@link org.eclipse.ice.commands.FileHandler#exists(java.lang.String)}.
+	 */
+	@Test
+	public void testExists() {
+		fail("Not yet implemented");
+	}
+
+}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/FileHandlerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/FileHandlerTest.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.ice.tests.commands;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCommandTest.java
@@ -13,16 +13,18 @@ package org.eclipse.ice.tests.commands;
 
 import static org.junit.Assert.fail;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * This class tests {@link org.eclipse.ice.commands.CommandFactory}.
- * 
- * @author Jay Jay Billings
+ * Test for class {@link org.eclipse.ice.commands.LocalCommand}.
+ * @author Joe Osborn
  *
  */
-public class CommandFactoryTest {
+public class LocalCommandTest {
 
 	/**
 	 * @throws java.lang.Exception
@@ -32,20 +34,37 @@ public class CommandFactoryTest {
 	}
 
 	/**
-	 * Test method for
-	 * {@link org.eclipse.ice.commands.CommandFactory#CommandFactory()}.
+	 * @throws java.lang.Exception
 	 */
-	@Test
-	public void testCommandFactory() {
-		fail("Not yet implemented");
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#get()}.
+	 * @throws java.lang.Exception
 	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
 	@Test
-	public void testGetCommand() {
+	public void test() {
 		fail("Not yet implemented");
 	}
+	
+	/**
+	 * Test for method {@link org.eclipse.ice.commands.LocalCommand()}
+	 */
+	public void testLocalCommand() {
+		fail("Not yet implemented");
+	}
+	
 
 }

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCopyFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCopyFileCommandTest.java
@@ -13,16 +13,18 @@ package org.eclipse.ice.tests.commands;
 
 import static org.junit.Assert.fail;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * This class tests {@link org.eclipse.ice.commands.CommandFactory}.
- * 
- * @author Jay Jay Billings
+ * Test for class {@link org.eclipse.ice.commands.LocalCommand}.
+ * @author Joe Osborn 
  *
  */
-public class CommandFactoryTest {
+public class LocalCopyFileCommandTest {
 
 	/**
 	 * @throws java.lang.Exception
@@ -32,20 +34,34 @@ public class CommandFactoryTest {
 	}
 
 	/**
-	 * Test method for
-	 * {@link org.eclipse.ice.commands.CommandFactory#CommandFactory()}.
+	 * @throws java.lang.Exception
 	 */
-	@Test
-	public void testCommandFactory() {
-		fail("Not yet implemented");
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#get()}.
+	 * @throws java.lang.Exception
 	 */
-	@Test
-	public void testGetCommand() {
-		fail("Not yet implemented");
+	@Before
+	public void setUp() throws Exception {
 	}
 
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	@Test
+	public void test() {
+		fail("Not yet implemented");
+	}
+	/**
+	 * Test for method {@link org.eclipse.ice.commands.LocalCopyFileCommand()}
+	 */
+	public void testLocalCopyFileCommand() {
+		fail("Not yet implemented");
+	}
 }

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalMoveFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalMoveFileCommandTest.java
@@ -13,16 +13,18 @@ package org.eclipse.ice.tests.commands;
 
 import static org.junit.Assert.fail;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * This class tests {@link org.eclipse.ice.commands.CommandFactory}.
- * 
- * @author Jay Jay Billings
+ * Test for class {@link org.eclipse.ice.commands.LocalMoveFileCommand}.
+ * @author Joe Osborn
  *
  */
-public class CommandFactoryTest {
+public class LocalMoveFileCommandTest {
 
 	/**
 	 * @throws java.lang.Exception
@@ -32,19 +34,35 @@ public class CommandFactoryTest {
 	}
 
 	/**
-	 * Test method for
-	 * {@link org.eclipse.ice.commands.CommandFactory#CommandFactory()}.
+	 * @throws java.lang.Exception
 	 */
-	@Test
-	public void testCommandFactory() {
-		fail("Not yet implemented");
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#get()}.
+	 * @throws java.lang.Exception
 	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
 	@Test
-	public void testGetCommand() {
+	public void test() {
+		fail("Not yet implemented");
+	}
+	
+	/**
+	 * Test for method {@link org.eclipse.ice.commands.LocalMoveFileCommand()}
+	 */
+	public void testLocalMoveFileCommand() {
 		fail("Not yet implemented");
 	}
 

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/MoveFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/MoveFileCommandTest.java
@@ -13,16 +13,18 @@ package org.eclipse.ice.tests.commands;
 
 import static org.junit.Assert.fail;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * This class tests {@link org.eclipse.ice.commands.CommandFactory}.
- * 
- * @author Jay Jay Billings
+ * Test for class {@link org.eclipse.ice.commands.MoveFileCommand}.
+ * @author Joe Osborn
  *
  */
-public class CommandFactoryTest {
+public class MoveFileCommandTest {
 
 	/**
 	 * @throws java.lang.Exception
@@ -32,19 +34,35 @@ public class CommandFactoryTest {
 	}
 
 	/**
-	 * Test method for
-	 * {@link org.eclipse.ice.commands.CommandFactory#CommandFactory()}.
+	 * @throws java.lang.Exception
 	 */
-	@Test
-	public void testCommandFactory() {
-		fail("Not yet implemented");
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#get()}.
+	 * @throws java.lang.Exception
 	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
 	@Test
-	public void testGetCommand() {
+	public void test() {
+		fail("Not yet implemented");
+	}
+	
+	/**
+	 * Test for method {@link org.eclipse.ice.commands.MoveFileCommand()}
+	 */
+	public void testMoveFileCommand() {
 		fail("Not yet implemented");
 	}
 

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteCommandTest.java
@@ -1,5 +1,4 @@
-/**
- * /*******************************************************************************
+/*******************************************************************************
  * Copyright (c) 2019- UT-Battelle, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -7,8 +6,8 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
- *   Joe Osborn
+ *   Initial API and implementation and/or initial documentation - 
+ *   Jay Jay Billings, Joe Osborn
  *******************************************************************************/
 package org.eclipse.ice.tests.commands;
 
@@ -21,11 +20,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test for class {@link org.eclipse.ice.commands.Command}.
+ * Test for class {@link org.eclipse.ice.commands.RemoteCommand}.
  * @author Joe Osborn
  *
  */
-public class CommandTest {
+public class RemoteCommandTest {
 
 	/**
 	 * @throws java.lang.Exception
@@ -54,34 +53,30 @@ public class CommandTest {
 	@After
 	public void tearDown() throws Exception {
 	}
-
+	
 	@Test
 	public void test() {
 		fail("Not yet implemented");
 	}
 	
-	
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.Command#Command()}
+	 * Test for method {@link org.eclipse.ice.commands.RemoteCommand()}
 	 */
-	public void testCommand() {
+	public void testRemoteCommand() {
+		fail("Not yet implemented");
+	}
+
+	/**
+	 * Test method for {@link org.eclipse.ice.commands.RemoteCommand#SetConnection(String)}
+	 */
+	public void testSetConnection() {
 		fail("Not yet implemented");
 	}
 	
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.Command#execute(String)}
+	 * Test method for {@link org.eclipse.ice.commans.RemoteCommand#GetConnection(String)}
 	 */
-	public void testExecute() {
+	public void testGetConnection() {
 		fail("Not yet implemented");
 	}
-	
-	/**
-	 * Test method for {@link org.eclipse.ice.commands.Command#GetStatus()}
-	 */
-	public void testGetStatus() {
-		fail("Not yet implemented");
-	}
-	
-	
-	
 }

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteCopyFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteCopyFileCommandTest.java
@@ -13,16 +13,18 @@ package org.eclipse.ice.tests.commands;
 
 import static org.junit.Assert.fail;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * This class tests {@link org.eclipse.ice.commands.CommandFactory}.
- * 
- * @author Jay Jay Billings
+ * Test for class {@link org.eclipse.ice.commands.RemoteCopyFileCommand}.
+ * @author Joe Osborn
  *
  */
-public class CommandFactoryTest {
+public class RemoteCopyFileCommandTest {
 
 	/**
 	 * @throws java.lang.Exception
@@ -32,19 +34,35 @@ public class CommandFactoryTest {
 	}
 
 	/**
-	 * Test method for
-	 * {@link org.eclipse.ice.commands.CommandFactory#CommandFactory()}.
+	 * @throws java.lang.Exception
 	 */
-	@Test
-	public void testCommandFactory() {
-		fail("Not yet implemented");
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#get()}.
+	 * @throws java.lang.Exception
 	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
 	@Test
-	public void testGetCommand() {
+	public void test() {
+		fail("Not yet implemented");
+	}
+	
+	/**
+	 * Test for method {@link org.eclipse.ice.commands.RemoteCopyFileCommand()}
+	 */
+	public void testRemoteCopyFileCommand() {
 		fail("Not yet implemented");
 	}
 

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteMoveFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteMoveFileCommandTest.java
@@ -13,16 +13,18 @@ package org.eclipse.ice.tests.commands;
 
 import static org.junit.Assert.fail;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * This class tests {@link org.eclipse.ice.commands.CommandFactory}.
- * 
- * @author Jay Jay Billings
+ * Test for class {@link org.eclipse.ice.commands.RemoteMoveFileCommand}.
+ * @author Joe Osborn
  *
  */
-public class CommandFactoryTest {
+public class RemoteMoveFileCommandTest {
 
 	/**
 	 * @throws java.lang.Exception
@@ -32,19 +34,35 @@ public class CommandFactoryTest {
 	}
 
 	/**
-	 * Test method for
-	 * {@link org.eclipse.ice.commands.CommandFactory#CommandFactory()}.
+	 * @throws java.lang.Exception
 	 */
-	@Test
-	public void testCommandFactory() {
-		fail("Not yet implemented");
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#get()}.
+	 * @throws java.lang.Exception
 	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
 	@Test
-	public void testGetCommand() {
+	public void test() {
+		fail("Not yet implemented");
+	}
+	
+	/**
+	 * Test for method {@link org.eclipse.ice.commands.RemoteMoveFileCommand()}
+	 */
+	public void testRemoteMoveFileCommand() {
 		fail("Not yet implemented");
 	}
 


### PR DESCRIPTION
This PR introduces a basic class structure for the Commands API, which is being rewritten as discussed in [issue 384](https://github.com/eclipse/ice/issues/384).