### PR TITLE
FileHandler tests improved

### DIFF
--- a/org.eclipse.ice.commands/pom.xml
+++ b/org.eclipse.ice.commands/pom.xml
@@ -11,5 +11,15 @@
 			<artifactId>junit</artifactId>
 			<version>4.4</version>
 		</dependency>
+		<dependency>
+      		<groupId>org.slf4j</groupId>
+     	    <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.12</version>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+           <version>1.2.17</version>
+        </dependency>   
 	</dependencies>
 </project>

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
@@ -114,7 +114,7 @@ public abstract class Command{
 	 * It is overridden by the subclasses that require executables.
 	 * @return - String that is the executable to be run
 	 */
-	protected String fixExecutableName() {
+	protected String getExecutableName() {
 		return configuration.execDictionary.get("executable");
 	}
 	

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
@@ -26,6 +26,8 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -54,6 +56,12 @@ public abstract class Command{
 	 */
 	protected BufferedWriter stdOut = null, stdErr = null;
 	
+
+	/**
+	 * Logger for handling event messages and other information.
+	 */
+	protected static final Logger logger = LoggerFactory.getLogger(Command.class);
+	
 	/**
 	 * Reference to the Java process that is the job to be executed
 	 */
@@ -63,7 +71,6 @@ public abstract class Command{
 	 * The variable that actually handles the job execution at the command line
 	 */
 	protected ProcessBuilder jobBuilder;
-	
 	
 	
 	/**
@@ -228,6 +235,7 @@ public abstract class Command{
 	 * @param command - Command to be prepared for shell execution
 	 */
 	protected CommandStatus setupProcessBuilder(String command) {
+		
 		// Local declarations
 		String os = configuration.execDictionary.get("os");
 		ArrayList<String> commandList = new ArrayList<String>();
@@ -245,7 +253,7 @@ public abstract class Command{
 		// the OS is not windows
 		commandList.add(command);
 		
-		System.out.println("INFO: Full command going to ProcessBuilder is: " + commandList);
+		logger.info("Full command going to ProcessBuilder is: " + commandList);
 		// Make the ProcessBuilder to execute the command
 		jobBuilder = new ProcessBuilder(commandList);
 		
@@ -344,7 +352,7 @@ public abstract class Command{
 				stdErr.close();
 			}
 			catch (IOException e){
-				System.out.println("FAILURE: There were errors in the job running, but they could not write to the error log file!");
+				logger.error("There were errors in the job running, but they could not write to the error log file!");
 				return CommandStatus.FAILED;
 			}
 			
@@ -368,7 +376,7 @@ public abstract class Command{
 			// The job is still running, so it should be watched by the 
 			// {@link org.eclipse.ice.commands.Command.monitorJob()} function
 		
-			System.out.println("Job didn't finish, going to monitorJob now");
+			logger.info("Job didn't finish, going to monitorJob now");
 			return CommandStatus.RUNNING;
 		}
 		// By convention exit values other than zero mean that the program
@@ -501,7 +509,7 @@ public abstract class Command{
 			}
 		} catch (IOException e) {
 			// Or fail and complain about it.
-			System.out.println("FAILURE: Could not logOutput, returning error!");
+			logger.error("Could not logOutput, returning error!");
 			return false;
 		}
 		
@@ -520,12 +528,12 @@ public abstract class Command{
 	public void checkStatus(CommandStatus current_status) throws IOException{
 		
 		if ( current_status != CommandStatus.FAILED && current_status != CommandStatus.INFOERROR) {
-			System.out.println("INFO: The current status is: " + current_status);
+			logger.info("The current status is: " + current_status);
 			return;
 		}
 		else {
-			System.out.println("FAILURE: The job failed with status: " + current_status);
-			System.out.println("Check your error logfile for more details! Exiting now!");
+			logger.error("The job failed with status: " + current_status);
+			logger.error("Check your error logfile for more details! Exiting now!");
 			throw new IOException();
 		}
 		

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
@@ -401,7 +401,6 @@ public abstract class Command{
 	 * successfully.
 	 */
 	protected CommandStatus monitorJob()  {
-
 		
 		// Local Declarations
 		int exitValue = -1; // Totally arbitrary
@@ -443,10 +442,11 @@ public abstract class Command{
 			// If for some reason the job has failed,
 			// it shouldn't be alive and we should break;
 			if (!job.isAlive()) {
+				logger.info("Job is no longer alive, no longer monitoring it's status");
 				break;
 			}
 		}
-		
+	
 		// Print the final exitValue of the job to the output log file
 		try {
 			stdOut.write("INFO: Command::monitorJob Message: Exit value = " + exitValue + "\n");
@@ -454,7 +454,8 @@ public abstract class Command{
 		catch (IOException e) {
 			e.printStackTrace();
 		}
-
+		
+		logger.info("Finished monitoring job with exit value: " + exitValue);
 		if(exitValue == 0)
 			return CommandStatus.SUCCESS;
 		else

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Command.java
@@ -11,6 +11,7 @@
  *   Joe Osborn
  *******************************************************************************/
 package org.eclipse.ice.commands;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -29,69 +30,70 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
- * This class is the instantiation class of the CommandFactory class and thus
- * is responsible for executing particular commands. It delegates the creation of a 
+ * This class is the instantiation class of the CommandFactory class and thus is
+ * responsible for executing particular commands. It delegates the creation of a
  * LocalCommand or RemoteCommand, depending on the hostname.
+ * 
  * @author Joe Osborn
  *
  */
-public abstract class Command{
+public abstract class Command {
 
-	
 	/**
 	 * The current status of the command
 	 */
 	protected CommandStatus status;
-	
+
 	/**
-	 * The configuration parameters of the command - contains information about
-	 * what the command is actually intended to do (e.g. the executable filename).
+	 * The configuration parameters of the command - contains information about what
+	 * the command is actually intended to do (e.g. the executable filename).
 	 */
 	protected CommandConfiguration configuration;
-	
+
 	/**
 	 * Output streams for the job
 	 */
 	protected BufferedWriter stdOut = null, stdErr = null;
-	
 
 	/**
 	 * Logger for handling event messages and other information.
 	 */
 	protected static final Logger logger = LoggerFactory.getLogger(Command.class);
-	
+
 	/**
 	 * Reference to the Java process that is the job to be executed
 	 */
 	private Process job;
-	
+
 	/**
 	 * The variable that actually handles the job execution at the command line
 	 */
 	protected ProcessBuilder jobBuilder;
-	
-	
+
 	/**
 	 * Default constructor
 	 */
-	public Command() {}
-	
-	/**
-	 * This function executes the command based on the information provided in the dictionary
-	 * which is stored in the CommandConfiguration.
-	 * @return CommandStatus - indicating whether or not the Command was properly executed
-	 */
-	public abstract CommandStatus execute();
-	
+	public Command() {
+	}
 
 	/**
-	 * This function sets the CommandConfiguration for a particular command.
-	 * It also prepares various files for job launch (e.g. logfiles) and is called
-	 * at construction time. It is overriden by LocalCommand and RemoteCommand
+	 * This function executes the command based on the information provided in the
+	 * dictionary which is stored in the CommandConfiguration.
+	 * 
+	 * @return CommandStatus - indicating whether or not the Command was properly
+	 *         executed
+	 */
+	public abstract CommandStatus execute();
+
+	/**
+	 * This function sets the CommandConfiguration for a particular command. It also
+	 * prepares various files for job launch (e.g. logfiles) and is called at
+	 * construction time. It is overriden by LocalCommand and RemoteCommand
+	 * 
 	 * @param config - the configuration to be used for a particular command.
-	 * @return CommandStatus - status indicating whether the configuration was properly set
+	 * @return CommandStatus - status indicating whether the configuration was
+	 *         properly set
 	 */
 	protected CommandStatus setConfiguration(CommandConfiguration config) {
 		configuration = config;
@@ -99,69 +101,75 @@ public abstract class Command{
 	}
 
 	/**
-	 * This function actually runs the particular command in question. It is called in execute()
-	 * after all of the setup for the job execution is finished.
+	 * This function actually runs the particular command in question. It is called
+	 * in execute() after all of the setup for the job execution is finished.
+	 * 
 	 * @return - CommandStatus indicating the result of the function.
 	 */
 	protected abstract CommandStatus run();
-	
 
 	/**
 	 * This function cancels the already submitted command, if possible.
-	 * @return CommandStatus - indicates whether or not the Command was properly cancelled.
+	 * 
+	 * @return CommandStatus - indicates whether or not the Command was properly
+	 *         cancelled.
 	 */
 	public abstract CommandStatus cancel();
-	
-	
+
 	/**
-	 * This function actually assembles and fixes the name of the executable to be launched.
-	 * It replaces ${inputFile}, ${installDir} and other keys from the dictionary. The function
-	 * is abstract so that Local and Remote executable names can be handled individually,
-	 * since the remote target file system is not necessarily the same as the local. 
-	 * It is overridden by the subclasses that require executables.
+	 * This function actually assembles and fixes the name of the executable to be
+	 * launched. It replaces ${inputFile}, ${installDir} and other keys from the
+	 * dictionary. The function is abstract so that Local and Remote executable
+	 * names can be handled individually, since the remote target file system is not
+	 * necessarily the same as the local. It is overridden by the subclasses that
+	 * require executables.
+	 * 
 	 * @return - String that is the executable to be run
 	 */
 	protected String getExecutableName() {
 		return configuration.execDictionary.get("executable");
 	}
-	
-	
+
 	/**
-	 * This function returns the status for a particular command at a given time
-	 * in the operation of the command.
+	 * This function returns the status for a particular command at a given time in
+	 * the operation of the command.
+	 * 
 	 * @return - return current status for a particular command
 	 */
 	public CommandStatus getStatus() {
 		return status;
 	}
-	
+
 	/**
 	 * This function sets the status for a particular command to be stat
+	 * 
 	 * @param stat - new CommandStatus to be set
 	 */
 	public void setStatus(CommandStatus stat) {
 		status = stat;
 		return;
 	}
-	
+
 	/**
-	 * This function returns to the user the configuration that was used 
-	 * to create a particular command. Could be useful for accessing particular
-	 * details about the command.
+	 * This function returns to the user the configuration that was used to create a
+	 * particular command. Could be useful for accessing particular details about
+	 * the command.
+	 * 
 	 * @return - the particular configuration for this command
 	 */
 	public CommandConfiguration getConfiguration() {
 		return configuration;
 	}
-	
+
 	/**
 	 * This function creates and returns a BufferedWriter for appending text to the
 	 * file specified in the call
+	 * 
 	 * @param filename - file to append to
 	 * @return - buffered writer for appending
 	 */
 	protected BufferedWriter getBufferedWriter(String filename) {
-		
+
 		FileWriter writer = null;
 		BufferedWriter bufferedWriter = null;
 
@@ -169,21 +177,19 @@ public abstract class Command{
 		if (filename != null) {
 			try {
 				writer = new FileWriter(filename, true);
-			} 
-			catch (IOException e) {
+			} catch (IOException e) {
 				e.printStackTrace();
 			}
 			bufferedWriter = new BufferedWriter(writer);
 			return bufferedWriter;
-		}
-		else
+		} else
 			return null;
 	}
-	
-	
+
 	/**
-	 * This function creates a set of generic output header text useful for debugging
-	 * or informational purposes, for example in log files.
+	 * This function creates a set of generic output header text useful for
+	 * debugging or informational purposes, for example in log files.
+	 * 
 	 * @param logName - the particular log name
 	 * @return - A string with the corresponding header text
 	 */
@@ -195,187 +201,180 @@ public abstract class Command{
 		try {
 			InetAddress addr = InetAddress.getLocalHost();
 			localHostname = addr.getHostName();
-		} 
-		catch (UnknownHostException e) {
+		} catch (UnknownHostException e) {
 			e.printStackTrace();
 		}
-		
+
 		// Add the header file name so that it can be identified
 		header = "# Logfile type : " + logName + "\n";
 
 		// Add the date and time
 		header += "# Job launch date: ";
-		header += new SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar
-				.getInstance().getTime()) + "\n";
-		
+		header += new SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar.getInstance().getTime()) + "\n";
+
 		// Add the point of origin
 		header += "# Launch host: " + localHostname + "\n";
-		
+
 		// Add the target machine
 		header += "# Target host: " + configuration.execDictionary.get("hostname") + "\n";
-		
+
 		// Add the execution command
 		header += "# Command Executed: " + configuration.fullCommand + "\n";
-		
+
 		// Add the input file name
 		header += "# Input file: " + configuration.execDictionary.get("inputFile") + "\n";
-		
+
 		// Add an empty line
 		header += "\n";
 
 		return header;
 	}
-	
-	
+
 	/**
-	 * This function sets up the ProcessBuilder member variable to prepare for 
-	 * actually submitting the job process to the command line from Java. The function
-	 * adjusts the command based on the OS on which it shall run, and then creates
-	 * the variables necessary for the command line execution.
+	 * This function sets up the ProcessBuilder member variable to prepare for
+	 * actually submitting the job process to the command line from Java. The
+	 * function adjusts the command based on the OS on which it shall run, and then
+	 * creates the variables necessary for the command line execution.
+	 * 
 	 * @param command - Command to be prepared for shell execution
 	 */
 	protected CommandStatus setupProcessBuilder(String command) {
-		
+
 		// Local declarations
 		String os = configuration.execDictionary.get("os");
 		ArrayList<String> commandList = new ArrayList<String>();
-		
-		
+
 		// If the OS is anything other than Windows, then the process builder
 		// needs to be configured to launch bash in command mode to avoid weird
 		// escape sequences.
-		if( !os.toLowerCase().contains("win")) {
+		if (!os.toLowerCase().contains("win")) {
 			commandList.add("/bin/bash");
 			commandList.add("-c");
 		}
-		
-		// Now add the actual command to be processed, prepended with /bin/bash -c if 
+
+		// Now add the actual command to be processed, prepended with /bin/bash -c if
 		// the OS is not windows
 		commandList.add(command);
-		
+
 		logger.info("Full command going to ProcessBuilder is: " + commandList);
 		// Make the ProcessBuilder to execute the command
 		jobBuilder = new ProcessBuilder(commandList);
-		
+
 		// Set the directory to execute the job in
 		File directory = new File(configuration.execDictionary.get("workingDirectory"));
 		jobBuilder.directory(directory);
 		jobBuilder.redirectErrorStream(false);
-		
+
 		return CommandStatus.RUNNING;
 	}
-	
+
 	/**
-	 * This function is responsible for actually running the Process in the command line.
-	 * It catches exceptions in the event that the job can't be started.
+	 * This function is responsible for actually running the Process in the command
+	 * line. It catches exceptions in the event that the job can't be started.
 	 * 
 	 */
 	protected CommandStatus runProcessBuilder() {
-		
+
 		String os = configuration.execDictionary.get("os");
 		List<String> commandList = jobBuilder.command();
 		String errMsg = "";
-		
-		
+
 		// Check that the job hasn't been canceled and is ready to run
 		try {
-			if(status != CommandStatus.CANCELED)
+			if (status != CommandStatus.CANCELED)
 				job = jobBuilder.start();
-		}
-		catch (IOException e) {
-			
+		} catch (IOException e) {
+
 			// If not a windows machine, there was an error
-			if(!os.toLowerCase().contains("win")) {
+			if (!os.toLowerCase().contains("win")) {
 				// If there is an error, add it to errMsg
 				errMsg += e.getMessage() + "\n";
-			}
-			else {
+			} else {
 				// If this is a windows machine, try to run in the command prompt
 				commandList.add(0, "CMD");
 				commandList.add(1, "/C");
-				
+
 				// Reset the ProcessBuilder to reflect these changes
 				jobBuilder = new ProcessBuilder(commandList);
 				File directory = new File(configuration.execDictionary.get("workingDirectory"));
 				jobBuilder.directory(directory);
 				jobBuilder.redirectErrorStream(false);
-				
+
 				// Now try again to start the job
 				try {
-					if(status != CommandStatus.CANCELED)
+					if (status != CommandStatus.CANCELED)
 						job = jobBuilder.start();
-				}
-				catch (IOException e2) {
+				} catch (IOException e2) {
 					// If there is an error, add it to errMsg
 					errMsg += e2.getMessage() + "\n";
-				}	
-			}	
+				}
+			}
 		}
-		
+
 		// Clean up and log the output of the job
 		status = cleanProcessBuilder(errMsg);
-		
+
 		return status;
-		
+
 	}
-	
+
 	/**
-	 * This function cleans up the remaining tasks left after job processing. This is
-	 * mostly logging output files, and checking that the process actually finished
-	 * successfully according to the ProcessBuilder
-	 * @param errorMessage - A string of any potential errors that were thrown during
-	 * 						 job execution
-	 * @return - CommandStatus indicating whether or not the function processed correctly
+	 * This function cleans up the remaining tasks left after job processing. This
+	 * is mostly logging output files, and checking that the process actually
+	 * finished successfully according to the ProcessBuilder
+	 * 
+	 * @param errorMessage - A string of any potential errors that were thrown
+	 *                     during job execution
+	 * @return - CommandStatus indicating whether or not the function processed
+	 *         correctly
 	 */
 	protected CommandStatus cleanProcessBuilder(String errorMessage) {
-		
+
 		InputStream stdOutStream = null, stdErrStream = null;
 		String stdErrFileName = null, stdOutFileName = null;
-		
+
 		// Get the output file names
 		stdErrFileName = configuration.execDictionary.get("stdErrFileName");
 		stdOutFileName = configuration.execDictionary.get("stdOutFileName");
-		
-		int exitValue = -1; //arbitrary value indicating not completed (yet)
-		
+
+		int exitValue = -1; // arbitrary value indicating not completed (yet)
+
 		// If errMsg is not an empty String, then there were some errors and they
 		// should be written out to the log file
-		if( errorMessage != "" ) {
+		if (errorMessage != "") {
 			try {
 				// Get the filenames so that they can be written to
 				stdErr = getBufferedWriter(stdErrFileName);
 				stdOut = getBufferedWriter(stdOutFileName);
-				
+
 				// Write and close
 				stdErr.write(errorMessage);
 				stdOut.close();
 				stdErr.close();
-			}
-			catch (IOException e){
+			} catch (IOException e) {
 				logger.error("There were errors in the job running, but they could not write to the error log file!");
 				return CommandStatus.FAILED;
 			}
-			
+
 			return CommandStatus.FAILED;
 		}
-		
+
 		// Log the output of the job execution
 		stdOutStream = job.getInputStream();
 		stdErrStream = job.getErrorStream();
-		
+
 		// Check that output was correctly logged. If not, return error
-		if( logOutput(stdOutStream, stdErrStream) == false ) {
+		if (logOutput(stdOutStream, stdErrStream) == false) {
 			return CommandStatus.FAILED;
 		}
-			
+
 		// Try to get the exit value of the job
 		try {
 			exitValue = job.exitValue();
-		} 
-		catch (IllegalThreadStateException e) {
-			// The job is still running, so it should be watched by the 
+		} catch (IllegalThreadStateException e) {
+			// The job is still running, so it should be watched by the
 			// {@link org.eclipse.ice.commands.Command.monitorJob()} function
-		
+
 			logger.info("Job didn't finish, going to monitorJob now");
 			return CommandStatus.RUNNING;
 		}
@@ -383,28 +382,25 @@ public abstract class Command{
 		// failed. If it is not 0, mark the job as failed (since it finished).
 		if (exitValue == 0) {
 			return CommandStatus.SUCCESS;
-		} 
-		else {
+		} else {
 			return CommandStatus.FAILED;
 		}
-			
+
 	}
-	
-	
+
 	/**
-	 * This operation is responsible for monitoring the exit value of the
-	 * running job. If it does not finish after some time then the function
-	 * will print a message to the error output file. If the job has failed
-	 * then it stops monitoring and returns that the exit value of the job was 
-	 * unsuccessful. The function also writes to the output logfile what the actual
-	 * final job exit value is, so the user can always see if their job finished
-	 * successfully.
+	 * This operation is responsible for monitoring the exit value of the running
+	 * job. If it does not finish after some time then the function will print a
+	 * message to the error output file. If the job has failed then it stops
+	 * monitoring and returns that the exit value of the job was unsuccessful. The
+	 * function also writes to the output logfile what the actual final job exit
+	 * value is, so the user can always see if their job finished successfully.
 	 */
-	protected CommandStatus monitorJob()  {
-		
+	protected CommandStatus monitorJob() {
+
 		// Local Declarations
 		int exitValue = -1; // Totally arbitrary
-		
+
 		// Wait until the job exits. By convention an exit code of
 		// zero means that the job has succeeded. Watch it until it
 		// finishes.
@@ -413,13 +409,11 @@ public abstract class Command{
 			// If the job completed successfully this will be 0
 			try {
 				exitValue = job.exitValue();
-			} 
-			catch (IllegalThreadStateException e) {
-				// Complain, but keep watching			
+			} catch (IllegalThreadStateException e) {
+				// Complain, but keep watching
 				try {
-					stdErr.write(getClass().getName() + "IllegalThreadStateException!: " + e);	
-				} 
-				catch (IOException e1) {
+					stdErr.write(getClass().getName() + "IllegalThreadStateException!: " + e);
+				} catch (IOException e1) {
 					e1.printStackTrace();
 				}
 			}
@@ -428,17 +422,15 @@ public abstract class Command{
 				job.waitFor(1000, TimeUnit.MILLISECONDS);
 				// Try again
 				exitValue = job.exitValue();
-			} 
-			catch (InterruptedException e) {
+			} catch (InterruptedException e) {
 				// Complain
 				try {
 					stdErr.write(getClass().getName() + " InterruptedException!: " + e);
-				} 
-				catch (IOException e1) {
+				} catch (IOException e1) {
 					e1.printStackTrace();
 				}
 			}
-			
+
 			// If for some reason the job has failed,
 			// it shouldn't be alive and we should break;
 			if (!job.isAlive()) {
@@ -446,36 +438,32 @@ public abstract class Command{
 				break;
 			}
 		}
-	
+
 		// Print the final exitValue of the job to the output log file
 		try {
 			stdOut.write("INFO: Command::monitorJob Message: Exit value = " + exitValue + "\n");
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		logger.info("Finished monitoring job with exit value: " + exitValue);
-		if(exitValue == 0)
+		if (exitValue == 0)
 			return CommandStatus.SUCCESS;
 		else
 			return CommandStatus.FAILED;
 	}
-	
-	
-	
-	
+
 	/**
 	 * This function takes the given streams as parameters and logs them into an
-	 * output file. The function returns a boolean on whether or not the 
-	 * function completed successfully (and thus the streams were correctly 
-	 * written out).
+	 * output file. The function returns a boolean on whether or not the function
+	 * completed successfully (and thus the streams were correctly written out).
+	 * 
 	 * @param output - Output stream from the job
 	 * @param errors - Error stream from the job
 	 * @return - boolean - true if output was logged, false otherwise
 	 */
 	protected boolean logOutput(final InputStream output, final InputStream errors) {
-		
+
 		InputStreamReader stdOutStreamReader = null, stdErrStreamReader = null;
 		BufferedReader stdOutReader = null, stdErrReader = null;
 		String nextLine = null;
@@ -483,17 +471,17 @@ public abstract class Command{
 		// Setup the BufferedReader that will get stdout from the process.
 		stdOutStreamReader = new InputStreamReader(output);
 		stdOutReader = new BufferedReader(stdOutStreamReader);
-		
+
 		// Setup the BufferedReader that will get stderr from the process.
 		stdErrStreamReader = new InputStreamReader(errors);
 		stdErrReader = new BufferedReader(stdErrStreamReader);
 		stdErr = getBufferedWriter(configuration.execDictionary.get("stdErrFileName"));
 		stdOut = getBufferedWriter(configuration.execDictionary.get("stdOutFileName"));
-		
+
 		// Catch the stdout and stderr output
 		try {
 			// Write to the stdOut file
-			while ( ( nextLine = stdOutReader.readLine() ) != null ) {
+			while ((nextLine = stdOutReader.readLine()) != null) {
 				stdOut.write(nextLine);
 				// MUST put a new line for this type of writer. "\r\n" works on
 				// Windows and Unix-based systems.
@@ -513,32 +501,28 @@ public abstract class Command{
 			logger.error("Could not logOutput, returning error!");
 			return false;
 		}
-		
-		
+
 		// Completed successfully, return true
 		return true;
 	}
-	
-	
-	
+
 	/**
-	 * This function is a simple helper function to check and make sure that the 
+	 * This function is a simple helper function to check and make sure that the
 	 * command status is not set to a flagged error, e.g. failed.
+	 * 
 	 * @param current_status
 	 */
-	public void checkStatus(CommandStatus current_status) throws IOException{
-		
-		if ( current_status != CommandStatus.FAILED && current_status != CommandStatus.INFOERROR) {
+	public void checkStatus(CommandStatus current_status) throws IOException {
+
+		if (current_status != CommandStatus.FAILED && current_status != CommandStatus.INFOERROR) {
 			logger.info("The current status is: " + current_status);
 			return;
-		}
-		else {
+		} else {
 			logger.error("The job failed with status: " + current_status);
 			logger.error("Check your error logfile for more details! Exiting now!");
 			throw new IOException();
 		}
-		
+
 	}
-	
-	
+
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandConfiguration.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandConfiguration.java
@@ -10,7 +10,7 @@
  *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
  *   Joe Osborn
  *******************************************************************************/
- 
+
 package org.eclipse.ice.commands;
 
 import java.util.ArrayList;
@@ -18,10 +18,11 @@ import java.util.HashMap;
 
 /**
  * 
- * This class configures particular commands to be executed. It contains all of the 
- * relevant information about configuring the command. The user should specify the
- * details of the command in the declaration of a Command instance by providing a 
- * CommandConfiguration.
+ * This class configures particular commands to be executed. It contains all of
+ * the relevant information about configuring the command. The user should
+ * specify the details of the command in the declaration of a Command instance
+ * by providing a CommandConfiguration.
+ * 
  * @author Joe Osborn
  *
  */
@@ -31,38 +32,37 @@ public class CommandConfiguration {
 	 * An integer ID to associate with a job
 	 */
 	protected int commandId;
-	
+
 	/**
 	 * The dictionary that contains the command properties.
 	 */
-	protected HashMap<String,String> execDictionary = new HashMap<String, String>();
-	
+	protected HashMap<String, String> execDictionary = new HashMap<String, String>();
+
 	/**
-	 * A flag to mark whether or not the input file name should be appended to the executable command.
-	 * Marked as true by default so that the user (by default) specifies the input file name.
+	 * A flag to mark whether or not the input file name should be appended to the
+	 * executable command. Marked as true by default so that the user (by default)
+	 * specifies the input file name.
 	 */
 	protected boolean appendInput = true;
-	
-	
+
 	/**
 	 * The full command string of all stages that will be executed.
 	 */
 	protected String fullCommand = "";
-	
+
 	/**
-	 * The set of commands in the fullCommand string split into stages. Each command is then executed separately.
-	 * If the command is single stage, then splitCommand is identical to fullCommand.
+	 * The set of commands in the fullCommand string split into stages. Each command
+	 * is then executed separately. If the command is single stage, then
+	 * splitCommand is identical to fullCommand.
 	 */
 	protected ArrayList<String> splitCommand = new ArrayList<String>();
-	
-	
+
 	/**
 	 * The name of the working directory in which the job will be launched. The
 	 * default value is the prefix.
 	 */
 	protected String workingDirectoryName = "";
-	
-	
+
 	/**
 	 * Default constructor
 	 */
@@ -72,45 +72,46 @@ public class CommandConfiguration {
 	}
 
 	/**
-	 * Constructor which initializes several of the member variables
-	 * See member variables in class CommandConfiguration for descriptions of variables
+	 * Constructor which initializes several of the member variables See member
+	 * variables in class CommandConfiguration for descriptions of variables
+	 * 
 	 * @param _commandId
 	 * @param _isLocal
 	 * @param _execDictionary
 	 * @param _appendInput
 	 */
-	public CommandConfiguration(int _commandId, 
-			HashMap<String,String> _execDictionary, boolean _appendInput) {
+	public CommandConfiguration(int _commandId, HashMap<String, String> _execDictionary, boolean _appendInput) {
 		commandId = _commandId;
 		execDictionary = _execDictionary;
 		appendInput = _appendInput;
-		
+
 	}
-	
-	
-	
+
 	/**
 	 * Make some getter and setter functions to access the CommandConfigurations
 	 * protected variables
 	 */
-	
+
 	public void setCommandId(int _commandId) {
 		commandId = _commandId;
 		return;
 	}
+
 	public int getCommandId() {
 		return commandId;
 	}
+
 	public void setExecDictionary(HashMap<String, String> _dictionary) {
 		execDictionary = _dictionary;
 		return;
 	}
+
 	public void setAppendInput(boolean _appendInput) {
 		appendInput = _appendInput;
 		return;
 	}
-	
-	/** 
+
+	/**
 	 * Don't want a setter function for FullCommand since this is determined in
 	 * {@link org.eclipse.ice.commands.LocalCommand#fixExecutableName()}
 	 */

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandFactory.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandFactory.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.ice.commands;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -38,7 +39,7 @@ public class CommandFactory {
 	 * particular details of a given command.
 	 * @return Command
 	 */
-	public static Command getCommand(final CommandConfiguration configuration) {
+	public static Command getCommand(final CommandConfiguration configuration) throws IOException {
 
 		Command command = null;
 		String host = null;
@@ -49,13 +50,13 @@ public class CommandFactory {
 		}
 		else {
 			System.out.println("FAILURE: You didn't provide a Dictionary with the Command information to run! Exiting.");
-			System.exit(1);
+			throw new IOException();
 		}
 		
 		// If no host was provided, we don't know where to run the job
 		if (host == null) {
 			System.out.println("FAILURE: You didn't provide a hostname in the CommandConfiguration for the job to run on! Exiting.");
-			System.exit(1);
+			throw new IOException();
 		}
 		
 		// If it the host is local, get a LocalCommand. Otherwise, RemoteCommand

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandFactory.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandFactory.java
@@ -28,88 +28,84 @@ import org.slf4j.LoggerFactory;
  */
 public class CommandFactory {
 
-	
 	/**
 	 * Logger for handling event messages and other information.
 	 */
 	protected static final Logger logger = LoggerFactory.getLogger(Command.class);
-	
-	
-	
+
 	/**
 	 * Constructor
 	 */
-	public CommandFactory() {}
+	public CommandFactory() {
+	}
 
 	/**
-	 * Method which gets a command and subsequently executes it on a host
-	 * See also Command class {@link org.eclipse.ice.commands.Command}.
-	 * @param CommandConfiguration - the CommandConfiguration which holds the 
-	 * particular details of a given command.
+	 * Method which gets a command and subsequently executes it on a host See also
+	 * Command class {@link org.eclipse.ice.commands.Command}.
+	 * 
+	 * @param CommandConfiguration - the CommandConfiguration which holds the
+	 *                             particular details of a given command.
 	 * @return Command
 	 */
 	public static Command getCommand(final CommandConfiguration configuration) throws IOException {
 		// Necessary for logger to print to console correctly
-		//BasicConfigurator.configure();
-		
-	
+		// BasicConfigurator.configure();
+
 		Command command = null;
 		String host = null;
-		
+
 		// Check to make sure that a hostname was provided for this command
-		if( configuration.execDictionary != null) {
+		if (configuration.execDictionary != null) {
 			host = configuration.execDictionary.get("hostname");
-		}
-		else {
+		} else {
 			logger.error("You didn't provide a Dictionary with the Command information to run! Exiting.");
 			throw new IOException();
 		}
-		
+
 		// If no host was provided, we don't know where to run the job
 		if (host == null) {
 			logger.error("You didn't provide a hostname in the CommandConfiguration for the job to run on! Exiting.");
 			throw new IOException();
 		}
-		
+
 		// If it the host is local, get a LocalCommand. Otherwise, RemoteCommand
-		if(isLocal(host)) {
+		if (isLocal(host)) {
 			command = new LocalCommand(configuration);
-		}
-		else {
+		} else {
 			Connection connect = new Connection();
 			command = new RemoteCommand(connect, configuration);
 		}
-	
+
 		return command;
-		
+
 	}
-	
+
 	/**
-	 * A function to check whether or not the provided hostname by the user
-	 * in CommandFactory is a local hostname or remote hostname.
+	 * A function to check whether or not the provided hostname by the user in
+	 * CommandFactory is a local hostname or remote hostname.
+	 * 
 	 * @param host - String of the hostname to be checked
-	 * @return boolean - returns true if the hostname matches that of the local hostname,
-	 * 					 false otherwise.
+	 * @return boolean - returns true if the hostname matches that of the local
+	 *         hostname, false otherwise.
 	 */
 	private static boolean isLocal(String host) {
-		
+
 		// Get the local hostname address
 		InetAddress addr = null;
 		try {
 			addr = InetAddress.getLocalHost();
-		} 
-		catch (UnknownHostException e) {
+		} catch (UnknownHostException e) {
 			e.printStackTrace();
 		}
-		
+
 		String hostname = addr.getHostName();
-		
+
 		// If the local hostname is the same as the hostname provided, then it is local
-		if(hostname == host)
+		if (hostname == host)
 			return true;
 		else
 			return false;
-		
+
 	}
 
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandFactory.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandFactory.java
@@ -15,6 +15,9 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * The command factory simplifies the creation of Commands without revealing how
  * they are constructed. It is primarily used for creating generic commands,
@@ -25,12 +28,18 @@ import java.net.UnknownHostException;
  */
 public class CommandFactory {
 
+	
+	/**
+	 * Logger for handling event messages and other information.
+	 */
+	protected static final Logger logger = LoggerFactory.getLogger(Command.class);
+	
+	
+	
 	/**
 	 * Constructor
 	 */
-	public CommandFactory() {
-		
-	}
+	public CommandFactory() {}
 
 	/**
 	 * Method which gets a command and subsequently executes it on a host
@@ -40,7 +49,10 @@ public class CommandFactory {
 	 * @return Command
 	 */
 	public static Command getCommand(final CommandConfiguration configuration) throws IOException {
-
+		// Necessary for logger to print to console correctly
+		//BasicConfigurator.configure();
+		
+	
 		Command command = null;
 		String host = null;
 		
@@ -49,13 +61,13 @@ public class CommandFactory {
 			host = configuration.execDictionary.get("hostname");
 		}
 		else {
-			System.out.println("FAILURE: You didn't provide a Dictionary with the Command information to run! Exiting.");
+			logger.error("You didn't provide a Dictionary with the Command information to run! Exiting.");
 			throw new IOException();
 		}
 		
 		// If no host was provided, we don't know where to run the job
 		if (host == null) {
-			System.out.println("FAILURE: You didn't provide a hostname in the CommandConfiguration for the job to run on! Exiting.");
+			logger.error("You didn't provide a hostname in the CommandConfiguration for the job to run on! Exiting.");
 			throw new IOException();
 		}
 		

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandStatus.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandStatus.java
@@ -24,5 +24,3 @@ package org.eclipse.ice.commands;
 public enum CommandStatus{
 	SUCCESS, PROCESSING, RUNNING, INFOERROR, FAILED, CANCELED;
 }
-
-

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandStatus.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CommandStatus.java
@@ -22,7 +22,7 @@ package org.eclipse.ice.commands;
  */
 
 public enum CommandStatus{
-	SUCCESS, PROCESSING, LAUNCHING, RUNNING, INFOERROR, FAILED, CANCELED;
+	SUCCESS, PROCESSING, RUNNING, INFOERROR, FAILED, CANCELED;
 }
 
 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Connection.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/Connection.java
@@ -29,10 +29,9 @@ public class Connection {
 	 * A name identifier for a particular connection.
 	 */
 	private String name;
-	
-	
+
 	/**
-	 *  Default constructor
+	 * Default constructor
 	 */
 	public Connection() {
 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionConfiguration.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionConfiguration.java
@@ -24,13 +24,12 @@ public class ConnectionConfiguration {
 	 * Username to configure a particular connection
 	 */
 	private String username;
-	
+
 	/**
 	 * Password to configure a particular connection
 	 */
 	private String password;
-	
-	
+
 	/**
 	 * Default constructor
 	 */

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManager.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/ConnectionManager.java
@@ -10,33 +10,33 @@
  *   Jay Jay Billings, Joe Osborn
  *******************************************************************************/
 package org.eclipse.ice.commands;
+
 import java.util.ArrayList;
 
 /**
- * This factory class manages remote connections, and as such interfaces with all classes
- * that are associated with remote connections.
+ * This factory class manages remote connections, and as such interfaces with
+ * all classes that are associated with remote connections.
+ * 
  * @author Joe Osborn
  *
  */
 public class ConnectionManager {
 
-	
 	/**
 	 * An ArrayList of available Connections to the ConnectionManager
 	 */
 	protected ArrayList<Connection> connectionList = new ArrayList<Connection>();
-	
-	
-	
+
 	/**
 	 * Default Constructor
 	 */
 	public ConnectionManager() {
-		
+
 	}
-	
+
 	/**
 	 * Opens, and thus begins, a connection to either a remote system or process
+	 * 
 	 * @param connection - connection to be opened
 	 * @return Connection - returns connection
 	 */
@@ -46,31 +46,34 @@ public class ConnectionManager {
 
 	/**
 	 * Gets the connection from an already opened connection.
-	 * @param connection - connection to be returned having already been instantiated
+	 * 
+	 * @param connection - connection to be returned having already been
+	 *                   instantiated
 	 * @return Connection - returns connection asked for
 	 */
 	public static Connection getConnection(String connection) {
 		return null;
 	}
-	
+
 	/**
 	 * Closes a particular connection as specified
+	 * 
 	 * @param connection - Connection to be closed
-	 * @return boolean - returns true if connection was successfully closed, otherwise false
+	 * @return boolean - returns true if connection was successfully closed,
+	 *         otherwise false
 	 */
 	public boolean closeConnection(Connection connection) {
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Closes all connections that remain open.
+	 * 
 	 * @return - true if successfully closed all connections, otherwise false
 	 */
 	public boolean closeAllConnections() {
 		return false;
 	}
-	
-	
-	
+
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/CopyFileCommand.java
@@ -15,29 +15,28 @@ package org.eclipse.ice.commands;
 import java.nio.file.Path;
 
 /**
- * Parent class for remote and local copy file commands. Inherits
- * from FileHandler and is responsible for executing copy file commands.
+ * Parent class for remote and local copy file commands. Inherits from
+ * FileHandler and is responsible for executing copy file commands.
+ * 
  * @author Joe Osborn
  *
  */
 public abstract class CopyFileCommand extends Command {
 
-	
 	/**
 	 * The path to the source file which is to be copied
 	 */
 	Path source;
-	
+
 	/**
 	 * The path of the destination for which the source file will be copied to
 	 */
 	Path destination;
-	
-	
+
 	/**
 	 * Default constructor
 	 */
-	public CopyFileCommand() {}
-	
-	
+	public CopyFileCommand() {
+	}
+
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
@@ -34,16 +34,15 @@ public class FileHandler {
 	}
 
 	/**
-	 * This operations moves files from the source (src) to the destination
+	 * This operation moves files from the source (src) to the destination
 	 * (dest). If the operation fails, an IOException will be thrown.
 	 * 
-	 * @param src
-	 * @param dest
-	 * @param hostname
-	 * @return CommandStatus - status indicating move was successfully completed
+	 * @param src - source file to be moved
+	 * @param dest - destination for the source file to be moved to
+	 * @return Command - The command to be executed
 	 * @throws IOException
 	 */
-	public static void move(final String src, final String dest) throws IOException {
+	public static Command move(final String src, final String dest) throws IOException {
 		
 		MoveFileCommand command = null;
 		
@@ -80,19 +79,19 @@ public class FileHandler {
 			}
 		}
 		
-		return;
+		return command;
 	}
 
 	/**
 	 * This operations copies files from the source (src) to the destination
 	 * (dest). If the operation fails, an IOException will be thrown. 
 	 * 
-	 * @param src
-	 * @param dest
-	 * @return CommandStatus - status indicating copy was successfully completed
+	 * @param src - source file to be copied
+	 * @param dest - destination to be copied to
+	 * @return Command - The actual Command to be executed
 	 * @throws IOException
 	 */
-	public static void copy(final String src, final String dest) throws IOException {
+	public static Command copy(final String src, final String dest) throws IOException {
 		
 		CopyFileCommand command = null;
 	
@@ -131,7 +130,7 @@ public class FileHandler {
 			System.out.println("The source file does not exist! Doing nothing.");
 		}
 			
-		return;
+		return command;
 	}
 
 	/**

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
@@ -34,108 +34,104 @@ public class FileHandler {
 	}
 
 	/**
-	 * This operation moves files from the source (src) to the destination
-	 * (dest). If the operation fails, an IOException will be thrown.
+	 * This operation moves files from the source (src) to the destination (dest).
+	 * If the operation fails, an IOException will be thrown.
 	 * 
-	 * @param src - source file to be moved
+	 * @param src  - source file to be moved
 	 * @param dest - destination for the source file to be moved to
 	 * @return Command - The command to be executed
 	 * @throws IOException
 	 */
 	public static Command move(final String src, final String dest) throws IOException {
-		
+
 		MoveFileCommand command = null;
-		
-		// Just test local moving for now. 
-		
-		//TODO need to determine how to differentiate local vs. remote moves with just
+
+		// Just test local moving for now.
+
+		// TODO need to determine how to differentiate local vs. remote moves with just
 		// the strings and not a hostname
 		boolean isLocal = true;
-		
+
 		// Check to make sure the paths exist
 		boolean sourceExists = exists(src);
 		boolean destExists = exists(dest);
-	
+
 		// If destination doesn't exist, create it
-		if(!destExists) {
+		if (!destExists) {
 			try {
 				Path destination = Paths.get(dest);
 				Files.createDirectories(destination);
 				// If an exception wasn't thrown, the destination exists
 				destExists = true;
-			}
-			catch(IOException e) {
+			} catch (IOException e) {
 				System.out.println("Couldn't create directory for local copy! Failed.");
 				e.printStackTrace();
 			}
 		}
-				
-		if(sourceExists && destExists) {
-			if(isLocal) {
+
+		if (sourceExists && destExists) {
+			if (isLocal) {
 				command = new LocalMoveFileCommand(src, dest);
-			}
-			else {
+			} else {
 				command = new RemoteMoveFileCommand(src, dest);
 			}
 		}
-		
+
 		return command;
 	}
 
 	/**
-	 * This operations copies files from the source (src) to the destination
-	 * (dest). If the operation fails, an IOException will be thrown. 
+	 * This operations copies files from the source (src) to the destination (dest).
+	 * If the operation fails, an IOException will be thrown.
 	 * 
-	 * @param src - source file to be copied
+	 * @param src  - source file to be copied
 	 * @param dest - destination to be copied to
 	 * @return Command - The actual Command to be executed
 	 * @throws IOException
 	 */
 	public static Command copy(final String src, final String dest) throws IOException {
-		
+
 		CopyFileCommand command = null;
-	
-		//TODO need to determine how to differentiate local vs. remote copies/moves with just
+
+		// TODO need to determine how to differentiate local vs. remote copies/moves
+		// with just
 		// the strings and not a hostname
 		boolean isLocal = true;
-		
-		
+
 		// Check to make sure the source exists
 		boolean sourceExists = exists(src);
 		boolean destExists = exists(dest);
-		
+
 		// If destination doesn't exist, create it
-		if(!destExists) {
+		if (!destExists) {
 			try {
 				Path destination = Paths.get(dest);
 				Files.createDirectories(destination);
 				// If an exception wasn't thrown, then destination now exists
 				destExists = true;
-			}
-			catch(IOException e) {
+			} catch (IOException e) {
 				System.out.println("Couldn't create directory for local move! Failed.");
 				e.printStackTrace();
 			}
 		}
-		
-		if(sourceExists && destExists) {
-			if(isLocal) {
+
+		if (sourceExists && destExists) {
+			if (isLocal) {
 				command = new LocalCopyFileCommand(src, dest);
-			}
-			else {
+			} else {
 				command = new RemoteCopyFileCommand(src, dest);
 			}
-		}
-		else {
+		} else {
 			System.out.println("The source file does not exist! Doing nothing.");
 		}
-			
+
 		return command;
 	}
 
 	/**
-	 * This operations determines whether or not the file argument exists.
-	 * TODO - this only works for local files at the moment.
+	 * This operations determines whether or not the file argument exists. TODO -
+	 * this only works for local files at the moment.
+	 * 
 	 * @param file the file for which to search
 	 * @return true if the file exists, false if not
 	 * @throws IOException
@@ -144,13 +140,10 @@ public class FileHandler {
 
 		// Get the path from the passed string
 		Path path = Paths.get(file);
-		
+
 		// Check if the path exists or not. Symbolic links are followed
 		// by default, see {@link java.nio.file.Files#exists}
 		return Files.exists(path);
 	}
 
-	
-
-	
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/FileHandler.java
@@ -55,9 +55,23 @@ public class FileHandler {
 		
 		// Check to make sure the paths exist
 		boolean sourceExists = exists(src);
-		
+		boolean destExists = exists(dest);
+	
+		// If destination doesn't exist, create it
+		if(!destExists) {
+			try {
+				Path destination = Paths.get(dest);
+				Files.createDirectories(destination);
+				// If an exception wasn't thrown, the destination exists
+				destExists = true;
+			}
+			catch(IOException e) {
+				System.out.println("Couldn't create directory for local copy! Failed.");
+				e.printStackTrace();
+			}
+		}
 				
-		if(sourceExists) {
+		if(sourceExists && destExists) {
 			if(isLocal) {
 				command = new LocalMoveFileCommand(src, dest);
 			}
@@ -88,11 +102,24 @@ public class FileHandler {
 		
 		
 		// Check to make sure the source exists
-		// Check destination existing in individual Command classes, since it can
-		// be made to exist
 		boolean sourceExists = exists(src);
+		boolean destExists = exists(dest);
 		
-		if(sourceExists) {
+		// If destination doesn't exist, create it
+		if(!destExists) {
+			try {
+				Path destination = Paths.get(dest);
+				Files.createDirectories(destination);
+				// If an exception wasn't thrown, then destination now exists
+				destExists = true;
+			}
+			catch(IOException e) {
+				System.out.println("Couldn't create directory for local move! Failed.");
+				e.printStackTrace();
+			}
+		}
+		
+		if(sourceExists && destExists) {
 			if(isLocal) {
 				command = new LocalCopyFileCommand(src, dest);
 			}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
@@ -15,66 +15,68 @@ package org.eclipse.ice.commands;
 import java.io.IOException;
 
 /**
- * This class inherits from Command and gives available functionality for local commands.
- * The processing and running of the LocalCommand is performed here.
+ * This class inherits from Command and gives available functionality for local
+ * commands. The processing and running of the LocalCommand is performed here.
+ * 
  * @author Joe Osborn
  *
  */
-public class LocalCommand extends Command{
+public class LocalCommand extends Command {
 
 	/**
 	 * Default constructor
 	 */
-	public LocalCommand() {}
-	
+	public LocalCommand() {
+	}
 
 	/**
-	 * Constructor which specifies a particular command configuration. The command configuration
-	 * should contain all of the necessary details for a particular command to run. See in particular
-	 * the function {@link org.eclipse.ice.commands.LocalCommand#setConfiguration(CommandConfiguration)}
+	 * Constructor which specifies a particular command configuration. The command
+	 * configuration should contain all of the necessary details for a particular
+	 * command to run. See in particular the function
+	 * {@link org.eclipse.ice.commands.LocalCommand#setConfiguration(CommandConfiguration)}
 	 * for details about what details are required.
+	 * 
 	 * @param _configuration
 	 */
 	public LocalCommand(CommandConfiguration _configuration) {
-	
+
 		status = CommandStatus.PROCESSING;
-		status = setConfiguration(_configuration);	
+		status = setConfiguration(_configuration);
 	}
-	
-	
+
 	/**
-	 * Method that overrides {@link org.eclipse.ice.commands.Command#execute()} and actually implements
-	 * the particular LocalCommand to be executed.
+	 * Method that overrides {@link org.eclipse.ice.commands.Command#execute()} and
+	 * actually implements the particular LocalCommand to be executed.
 	 */
 	@Override
 	public CommandStatus execute() {
-		
+
 		// Check that the status of the job is good after setting up the configuration
-		// in the constructor. If not, exit 
+		// in the constructor. If not, exit
 		// See CheckStatus function in {@link org.eclipse.ice.commands.Command}
 		try {
 			checkStatus(status);
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-			
+
 		// Now that all of the prerequisites have been set, start the job running
 		status = run();
-		
+
 		logger.info("The job finished with status: " + status);
 		return status;
 	}
-	
+
 	/**
-	 * See {@link org.eclipse.ice.commands.Command#setConfiguration(CommandConfiguration)}
+	 * See
+	 * {@link org.eclipse.ice.commands.Command#setConfiguration(CommandConfiguration)}
 	 */
 	@Override
 	protected CommandStatus setConfiguration(final CommandConfiguration config) {
-		
+
 		// Set the configuration for the command
 		configuration = config;
-		
+
 		// Now extract the information from the command dictionary
 		String executable = null, inputFile = null;
 		String stdOutFileName = null, stdErrFileName = null;
@@ -84,7 +86,7 @@ public class LocalCommand extends Command{
 
 		// Make sure the dictionary was actually set
 		if (configuration.execDictionary != null) {
-			
+
 			// Make sure the dictionary contains the keys we need
 			executable = configuration.execDictionary.get("executable");
 			inputFile = configuration.execDictionary.get("inputFile");
@@ -94,27 +96,23 @@ public class LocalCommand extends Command{
 			installDir = configuration.execDictionary.get("installDir");
 			os = configuration.execDictionary.get("os");
 			directory = configuration.execDictionary.get("workingDirectory");
-		}
-		else
+		} else
 			return CommandStatus.INFOERROR;
-		
+
 		// Check the info and return failure if something was not set correctly
-		if (executable == null || inputFile == null || stdOutFileName == null
-					|| stdErrFileName == null || numProcs == null || os == null
-					|| directory == null) 
-				return CommandStatus.INFOERROR;
-				
-		
-		
+		if (executable == null || inputFile == null || stdOutFileName == null || stdErrFileName == null
+				|| numProcs == null || os == null || directory == null)
+			return CommandStatus.INFOERROR;
+
 		// If the input file name should not be appended to the executable, set it
-		if ( configuration.execDictionary.get("noAppendInput") != null 
+		if (configuration.execDictionary.get("noAppendInput") != null
 				&& configuration.execDictionary.get("noAppendInput") == "true")
 			configuration.appendInput = false;
-		
+
 		// Set the command to actually run and execute
 		configuration.fullCommand = getExecutableName();
-		
-		//Set the output and error buffer writers
+
+		// Set the output and error buffer writers
 		stdOutFileName = configuration.execDictionary.get("stdOutFileName");
 		stdOut = getBufferedWriter(stdOutFileName);
 		stdErrFileName = configuration.execDictionary.get("stdErrFileName");
@@ -123,141 +121,133 @@ public class LocalCommand extends Command{
 		// Create unique headers for the output files which include useful information
 		stdOutHeader = createOutputHeader("standard output");
 		stdErrHeader = createOutputHeader("standard error");
-		
+
 		// Now write them out
-		try { 
+		try {
 			stdOut.write(stdOutHeader);
-			stdOut.write("# Executable to be run is: " + configuration.fullCommand +"\n");
+			stdOut.write("# Executable to be run is: " + configuration.fullCommand + "\n");
 			stdOut.close();
 			stdErr.write(stdErrHeader);
 			stdErr.close();
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		// All setup completed, return that the job will now run
 		return CommandStatus.RUNNING;
 	}
-	
+
 	/**
 	 * See {@link org.eclipse.ice.commands.Command#run()}
 	 */
 	@Override
 	protected CommandStatus run() {
-		
-		// Loop over the stages and launch them. This needs to be done 
+
+		// Loop over the stages and launch them. This needs to be done
 		// sequentially, so use a regular, non-concurrent access loop
-		for ( int i = 0; i < configuration.splitCommand.size(); i++) {
-			
+		for (int i = 0; i < configuration.splitCommand.size(); i++) {
+
 			// Check the status to ensure job has not been canceled
 			if (status == CommandStatus.CANCELED) {
 				logger.info("Job has been canceled, quitting now.");
 				break;
 			}
-			
+
 			// Get the command
 			String thisCommand = configuration.splitCommand.get(i);
-			
+
 			// Set up the process builder
 			status = setupProcessBuilder(thisCommand);
-			
+
 			// Run the job
 			status = runProcessBuilder();
-			
+
 			// Check the status to ensure the job hasn't failed
 			try {
 				checkStatus(status);
-			} 
-			catch (IOException e) {
+			} catch (IOException e) {
 				e.printStackTrace();
 			}
-				
-			
+
 			// Monitor the job to ensure it finished successfully or to watch it
 			// if it is still running
-			if(status != CommandStatus.SUCCESS && status != CommandStatus.FAILED) {
+			if (status != CommandStatus.SUCCESS && status != CommandStatus.FAILED) {
 				logger.info("Monitoring job");
 				status = monitorJob();
 			}
-			
+
 			// Now check again to see if the job succeeded
 			try {
 				checkStatus(status);
-			}
-			catch (IOException e){
+			} catch (IOException e) {
 				e.printStackTrace();
 			}
-			
+
 		}
-		
+
 		// Close up the output streams
-		try { 
+		try {
 			stdOut.close();
 			stdErr.close();
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			status = CommandStatus.INFOERROR;
 			logger.error("Could not close the output and/or error files, returning INFOERROR");
 			return status;
 		}
-		
-		
+
 		// Return the result
 		return status;
 	}
-	
-	
-	
+
 	/**
 	 * See {@link org.eclipse.ice.commands.Command#fixExecutableName()}
 	 */
 	@Override
 	protected String getExecutableName() {
-		
+
 		// Get the information from the executable dictionary
-		int numProcs = Math.max(1,
-				Integer.parseInt(configuration.execDictionary.get("numProcs")));
+		int numProcs = Math.max(1, Integer.parseInt(configuration.execDictionary.get("numProcs")));
 		String fixedExecutableName = configuration.execDictionary.get("executable");
 		String installDirectory = configuration.execDictionary.get("installDir");
 		String inputFile = configuration.execDictionary.get("inputFile");
 		String separator = "/";
-		
+
 		// Set the name of the working directory
 		configuration.workingDirectoryName = configuration.execDictionary.get("workingDirectory");
-		
+
 		// If the input file should be appended, append it
-		if(configuration.appendInput)
+		if (configuration.appendInput)
 			fixedExecutableName += " " + inputFile;
-		
+
 		configuration.fullCommand = fixedExecutableName;
-		
-		// Determine the proper separator 
+
+		// Determine the proper separator
 		if (installDirectory != null && installDirectory.contains(":\\"))
 			separator = "\\";
-		
+
 		// Append a final separator to the install directory if required
 		if (installDirectory != null && !installDirectory.endsWith(separator))
 			installDirectory = installDirectory + separator;
-		
+
 		// Search for and replace the ${inputFile} to properly configure the input file
 		if (fixedExecutableName.contains("${inputFile}") && !configuration.appendInput)
 			fixedExecutableName = fixedExecutableName.replace("${inputFile}", inputFile);
-		
-		if (fixedExecutableName.contains("${installDir}") && installDirectory != null) 
+
+		if (fixedExecutableName.contains("${installDir}") && installDirectory != null)
 			fixedExecutableName = fixedExecutableName.replace("${installDir}", installDirectory);
-		
+
 		// If MPI should be used if there are multiple cores, add it to the executable
-		if (numProcs > 1) 
+		if (numProcs > 1)
 			fixedExecutableName = "mpirun -np " + numProcs + " " + fixedExecutableName;
-		
-		//Clean up any unnecessary white space
+
+		// Clean up any unnecessary white space
 		fixedExecutableName = fixedExecutableName.trim();
-		
+
 		// Split the full command into its stages, if there are any.
-		if (!fixedExecutableName.contains(";")) 
+		if (!fixedExecutableName.contains(";"))
 			configuration.splitCommand.add(fixedExecutableName);
-		//Otherwise split the full command and put it into CommandConfiguration.splitCommand
+		// Otherwise split the full command and put it into
+		// CommandConfiguration.splitCommand
 		else {
 			for (String stage : fixedExecutableName.split(";"))
 				configuration.splitCommand.add(stage);
@@ -266,18 +256,16 @@ public class LocalCommand extends Command{
 		// Print launch stages so that user can confirm
 		for (int i = 0; i < configuration.splitCommand.size(); i++) {
 			String cmd = configuration.splitCommand.get(i);
-			logger.info("LocalCommand Message: Launch stage " + i
-					+ " = " + cmd);
+			logger.info("LocalCommand Message: Launch stage " + i + " = " + cmd);
 		}
 
 		return fixedExecutableName;
-		
+
 	}
-	
-	
+
 	/**
-	 * Method that overrides Commmand:Cancel and actually implements
-	 * the particular LocalCommand to be cancelled.
+	 * Method that overrides Commmand:Cancel and actually implements the particular
+	 * LocalCommand to be cancelled.
 	 */
 	@Override
 	public CommandStatus cancel() {
@@ -285,5 +273,4 @@ public class LocalCommand extends Command{
 		return status;
 	}
 
-	
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
@@ -111,7 +111,7 @@ public class LocalCommand extends Command{
 			configuration.appendInput = false;
 		
 		// Set the command to actually run and execute
-		configuration.fullCommand = fixExecutableName();
+		configuration.fullCommand = getExecutableName();
 		
 		//Set the output and error buffer writers
 		stdOutFileName = configuration.execDictionary.get("stdOutFileName");
@@ -212,7 +212,7 @@ public class LocalCommand extends Command{
 	 * See {@link org.eclipse.ice.commands.Command#fixExecutableName()}
 	 */
 	@Override
-	protected String fixExecutableName() {
+	protected String getExecutableName() {
 		
 		// Get the information from the executable dictionary
 		int numProcs = Math.max(1,

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
@@ -37,7 +37,7 @@ public class LocalCommand extends Command{
 	 */
 	public LocalCommand(CommandConfiguration _configuration) {
 	
-		status = CommandStatus.LAUNCHING;
+		status = CommandStatus.PROCESSING;
 		status = setConfiguration(_configuration);	
 	}
 	
@@ -176,7 +176,7 @@ public class LocalCommand extends Command{
 			
 			// Monitor the job to ensure it finished successfully or to watch it
 			// if it is still running
-			if(status != CommandStatus.SUCCESS) {
+			if(status != CommandStatus.SUCCESS && status != CommandStatus.FAILED) {
 				logger.info("Monitoring job");
 				status = monitorJob();
 			}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCommand.java
@@ -36,9 +36,9 @@ public class LocalCommand extends Command{
 	 * @param _configuration
 	 */
 	public LocalCommand(CommandConfiguration _configuration) {
+	
 		status = CommandStatus.LAUNCHING;
-		status = setConfiguration(_configuration);
-		
+		status = setConfiguration(_configuration);	
 	}
 	
 	
@@ -62,6 +62,7 @@ public class LocalCommand extends Command{
 		// Now that all of the prerequisites have been set, start the job running
 		status = run();
 		
+		logger.info("The job finished with status: " + status);
 		return status;
 	}
 	
@@ -151,7 +152,7 @@ public class LocalCommand extends Command{
 			
 			// Check the status to ensure job has not been canceled
 			if (status == CommandStatus.CANCELED) {
-				System.out.println("INFO: Job has been canceled, quitting now.");
+				logger.info("Job has been canceled, quitting now.");
 				break;
 			}
 			
@@ -176,7 +177,7 @@ public class LocalCommand extends Command{
 			// Monitor the job to ensure it finished successfully or to watch it
 			// if it is still running
 			if(status != CommandStatus.SUCCESS) {
-				System.out.println("INFO: Monitoring job");
+				logger.info("Monitoring job");
 				status = monitorJob();
 			}
 			
@@ -197,7 +198,7 @@ public class LocalCommand extends Command{
 		}
 		catch (IOException e) {
 			status = CommandStatus.INFOERROR;
-			System.out.println("INFO: Could not close the output and/or error files, returning INFOERROR");
+			logger.error("Could not close the output and/or error files, returning INFOERROR");
 			return status;
 		}
 		
@@ -265,7 +266,7 @@ public class LocalCommand extends Command{
 		// Print launch stages so that user can confirm
 		for (int i = 0; i < configuration.splitCommand.size(); i++) {
 			String cmd = configuration.splitCommand.get(i);
-			System.out.println("LocalCommand Message: Launch stage " + i
+			logger.info("LocalCommand Message: Launch stage " + i
 					+ " = " + cmd);
 		}
 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
@@ -44,26 +44,6 @@ public class LocalCopyFileCommand extends CopyFileCommand {
 		source = Paths.get(src);
 		destination = Paths.get(dest);
 		
-		boolean destExists = false;
-		// Check if the destination exists
-		try {
-			destExists = FileHandler.exists(dest);
-		} 
-		catch (IOException e1) {
-			e1.printStackTrace();
-		}
-		
-		// If destination doesn't exist, create it
-		if(!destExists) {
-			try {
-				Files.createDirectories(destination);
-			}
-			catch(IOException e) {
-				System.out.println("Couldn't create directory for local copy! Failed.");
-				e.printStackTrace();
-			}
-		}
-		
 		// Do the copying
 		status = execute();
 	}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
@@ -28,9 +28,7 @@ public class LocalCopyFileCommand extends CopyFileCommand {
 	/**
 	 * Default constructor
 	 */
-	public LocalCopyFileCommand() {
-		
-	}
+	public LocalCopyFileCommand() {}
 	
 	/**
 	 * Constructor which sets the two paths, source and destination,
@@ -43,9 +41,6 @@ public class LocalCopyFileCommand extends CopyFileCommand {
 	public LocalCopyFileCommand(final String src, final String dest) {
 		source = Paths.get(src);
 		destination = Paths.get(dest);
-		
-		// Do the copying
-		status = execute();
 	}
 	
 	/**

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalCopyFileCommand.java
@@ -31,11 +31,12 @@ public class LocalCopyFileCommand extends CopyFileCommand {
 	public LocalCopyFileCommand() {}
 	
 	/**
-	 * Constructor which sets the two paths, source and destination,
-	 * to those given by the arguments of the constructor. See 
-	 * {@link org.eclipse.ice.tests.commands.CopyFileCommand} for member
-	 * variable descriptions.
-	 * @param src 
+	 * Constructor which sets the two paths, source and destination, to those given
+	 * by the arguments of the constructor. See
+	 * {@link org.eclipse.ice.tests.commands.CopyFileCommand} for member variable
+	 * descriptions.
+	 * 
+	 * @param src
 	 * @param dest
 	 */
 	public LocalCopyFileCommand(final String src, final String dest) {

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
@@ -43,25 +43,6 @@ public class LocalMoveFileCommand extends MoveFileCommand {
 		source = Paths.get(src);
 		destination = Paths.get(dest);
 		
-		boolean destExists = false;
-		try {
-			destExists = FileHandler.exists(dest);
-		} 
-		catch (IOException e) {
-			e.printStackTrace();
-		}
-		
-		// If destination doesn't exist, create it
-		if(!destExists) {
-			try {
-				Files.createDirectories(destination);
-			}
-			catch(IOException e) {
-				System.out.println("Couldn't create directory for local move! Failed.");
-				e.printStackTrace();
-			}
-		}
-		
 		// Do the moving
 		status = execute();
 	}

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
@@ -27,9 +27,7 @@ public class LocalMoveFileCommand extends MoveFileCommand {
 	/**
 	 * Default constructor
 	 */
-	public LocalMoveFileCommand() {
-		
-	}
+	public LocalMoveFileCommand() {}
 	
 	/**
 	 * Constructor which sets the two paths, source and destination,
@@ -42,9 +40,6 @@ public class LocalMoveFileCommand extends MoveFileCommand {
 	public LocalMoveFileCommand(final String src, final String dest) {
 		source = Paths.get(src);
 		destination = Paths.get(dest);
-		
-		// Do the moving
-		status = execute();
 	}
 	
 	

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/LocalMoveFileCommand.java
@@ -19,6 +19,7 @@ import java.nio.file.Paths;
 
 /**
  * Child class for moving a file locally without a remote connection
+ * 
  * @author Joe Osborn
  *
  */
@@ -27,63 +28,62 @@ public class LocalMoveFileCommand extends MoveFileCommand {
 	/**
 	 * Default constructor
 	 */
-	public LocalMoveFileCommand() {}
-	
+	public LocalMoveFileCommand() {
+	}
+
 	/**
-	 * Constructor which sets the two paths, source and destination,
-	 * to those given by the arguments of the constructor. See 
-	 * {@link org.eclipse.ice.tests.commands.CopyFileCommand} for member
-	 * variable descriptions.
-	 * @param src 
+	 * Constructor which sets the two paths, source and destination, to those given
+	 * by the arguments of the constructor. See
+	 * {@link org.eclipse.ice.tests.commands.CopyFileCommand} for member variable
+	 * descriptions.
+	 * 
+	 * @param src
 	 * @param dest
 	 */
 	public LocalMoveFileCommand(final String src, final String dest) {
 		source = Paths.get(src);
 		destination = Paths.get(dest);
 	}
-	
-	
-	
+
 	/**
-	 * This function actually executes the move file command. It checks that
-	 * the move command was completed successfully. It returns a 
-	 * CommandStatus indicating whether or not the move was successful.
+	 * This function actually executes the move file command. It checks that the
+	 * move command was completed successfully. It returns a CommandStatus
+	 * indicating whether or not the move was successful.
+	 * 
 	 * @return CommandStatus
 	 */
 	@Override
 	public CommandStatus execute() {
 		status = run();
-		
+
 		boolean check = false;
 		try {
 			check = FileHandler.exists(source.toString());
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
-		if( check )
+
+		if (check)
 			return CommandStatus.SUCCESS;
 		else
 			return CommandStatus.FAILED;
 	}
 
-	
 	/**
-	 * This function contains the command to actually move the file. Returns
-	 * a CommandStatus indicating that the command is currently running and
-	 * needs to be checked that it completed correctly.
+	 * This function contains the command to actually move the file. Returns a
+	 * CommandStatus indicating that the command is currently running and needs to
+	 * be checked that it completed correctly.
+	 * 
 	 * @return CommandStatus
 	 */
 	@Override
 	protected CommandStatus run() {
 		try {
 			Files.move(source, destination.resolve(source.getFileName()));
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		return CommandStatus.RUNNING;
 	}
 
@@ -97,7 +97,4 @@ public class LocalMoveFileCommand extends MoveFileCommand {
 		return CommandStatus.CANCELED;
 	}
 
-
-
-	
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/MoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/MoveFileCommand.java
@@ -16,7 +16,8 @@ package org.eclipse.ice.commands;
 import java.nio.file.Path;
 
 /**
- * Parent class for remote and local move file commands. 
+ * Parent class for remote and local move file commands.
+ * 
  * @author Joe Osborn
  *
  */
@@ -26,17 +27,16 @@ public abstract class MoveFileCommand extends Command {
 	 * The path to the source file which is to be moved
 	 */
 	Path source;
-	
+
 	/**
 	 * The path of the destination for which the source file will be moved to
 	 */
 	Path destination;
-	
+
 	/**
 	 * Default constructor
 	 */
-	public MoveFileCommand() {}
-	
-	
-	
+	public MoveFileCommand() {
+	}
+
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
@@ -86,7 +86,7 @@ public class RemoteCommand extends Command{
 	 * See @{link {@link org.eclipse.ice.commands.Command#fixExecutableName()}
 	 */
 	@Override
-	protected String fixExecutableName() {
+	protected String getExecutableName() {
 		return null;
 	}
 	/**

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCommand.java
@@ -13,55 +13,55 @@
 package org.eclipse.ice.commands;
 
 /**
- * This class inherits from Command and gives available functionality for remote commands.
- * These could be ssh connections or a remote process.
+ * This class inherits from Command and gives available functionality for remote
+ * commands. These could be ssh connections or a remote process.
+ * 
  * @author Joe Osborn
  *
  */
-public class RemoteCommand extends Command{
+public class RemoteCommand extends Command {
 
-	
 	/**
-	 * The particular connection associated to a particular RemoteCommand.
-	 * Declare this up front since by definition a RemoteCommand must have a connection.
+	 * The particular connection associated to a particular RemoteCommand. Declare
+	 * this up front since by definition a RemoteCommand must have a connection.
 	 */
 	Connection connection = new Connection();
-	
+
 	/**
 	 * Default constructor
 	 */
 	public RemoteCommand() {
-		
+
 	}
-	
+
 	/**
-	 * Constructor to instantiate the remote command with a particular 
+	 * Constructor to instantiate the remote command with a particular
 	 * CommandConfiguration
+	 * 
 	 * @param - CommandConfiguration which corresponds to the particular command
 	 */
 	public RemoteCommand(Connection connect, CommandConfiguration config) {
 		configuration = config;
 	}
-	
+
 	@Override
 	/**
-	 * Method that overrides Commmand:Execute and actually implements
-	 * the particular RemoteCommand to be executed.
+	 * Method that overrides Commmand:Execute and actually implements the particular
+	 * RemoteCommand to be executed.
 	 */
 	public CommandStatus execute() {
 		return null;
 	}
-	
-	
+
 	@Override
 	/**
-	 * Method that overrides Commmand:Cancel and actually implements
-	 * the particular RemoteCommand to be cancelled.
+	 * Method that overrides Commmand:Cancel and actually implements the particular
+	 * RemoteCommand to be cancelled.
 	 */
 	public CommandStatus cancel() {
 		return null;
 	}
-	
+
 	/**
 	 * See {@link org.eclipse.ice.commands.Command#launch()}
 	 */
@@ -69,19 +69,16 @@ public class RemoteCommand extends Command{
 	protected CommandStatus setConfiguration(CommandConfiguration config) {
 		return null;
 	}
-	
 
-	
 	/**
 	 * See {@link org.eclipse.ice.commands.Command#run()}
 	 */
 	@Override
 	protected CommandStatus run() {
-		
-		
+
 		return status;
 	}
-	
+
 	/**
 	 * See @{link {@link org.eclipse.ice.commands.Command#fixExecutableName()}
 	 */
@@ -89,20 +86,23 @@ public class RemoteCommand extends Command{
 	protected String getExecutableName() {
 		return null;
 	}
+
 	/**
 	 * Set a particular connection for a particular RemoteCommand
+	 * 
 	 * @param connection - the connection for this command
 	 */
 	public void setConnection(String connection) {
-		
+
 	}
-	
+
 	/**
 	 * Return the connection associated to this RemoteCommand
+	 * 
 	 * @return - the connection for this command
 	 */
 	public Connection getConnection() {
-		
+
 		return connection;
 	}
 

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCopyFileCommand.java
@@ -25,9 +25,7 @@ public class RemoteCopyFileCommand extends CopyFileCommand {
 	/**
 	 * Default constructor
 	 */
-	public RemoteCopyFileCommand() {
-		
-	}
+	public RemoteCopyFileCommand() {}
 	
 	
 	/**
@@ -41,7 +39,6 @@ public class RemoteCopyFileCommand extends CopyFileCommand {
 	public RemoteCopyFileCommand(String src, String dest) {
 		source = Paths.get(src);
 		destination = Paths.get(dest);
-		status = execute();
 	}
 	
 	

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCopyFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteCopyFileCommand.java
@@ -16,7 +16,8 @@ package org.eclipse.ice.commands;
 import java.nio.file.Paths;
 
 /**
- * Child class for copying a file remotely over some connection. 
+ * Child class for copying a file remotely over some connection.
+ * 
  * @author Joe Osborn
  *
  */
@@ -25,24 +26,22 @@ public class RemoteCopyFileCommand extends CopyFileCommand {
 	/**
 	 * Default constructor
 	 */
-	public RemoteCopyFileCommand() {}
-	
-	
+	public RemoteCopyFileCommand() {
+	}
+
 	/**
-	 * Constructor which sets the two paths, source and destination,
-	 * to those given by the arguments of the constructor. See 
-	 * {@link org.eclipse.ice.tests.commands.CopyFileCommand} for member
-	 * variable descriptions.
-	 * @param src 
+	 * Constructor which sets the two paths, source and destination, to those given
+	 * by the arguments of the constructor. See
+	 * {@link org.eclipse.ice.tests.commands.CopyFileCommand} for member variable
+	 * descriptions.
+	 * 
+	 * @param src
 	 * @param dest
 	 */
 	public RemoteCopyFileCommand(String src, String dest) {
 		source = Paths.get(src);
 		destination = Paths.get(dest);
 	}
-	
-	
-
 
 	@Override
 	public CommandStatus execute() {
@@ -50,15 +49,11 @@ public class RemoteCopyFileCommand extends CopyFileCommand {
 		return null;
 	}
 
-
-
-
 	@Override
 	protected CommandStatus run() {
 		// TODO Auto-generated method stub
 		return null;
 	}
-
 
 	@Override
 	public CommandStatus cancel() {
@@ -66,6 +61,4 @@ public class RemoteCopyFileCommand extends CopyFileCommand {
 		return null;
 	}
 
-
-	
 }

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteMoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteMoveFileCommand.java
@@ -29,11 +29,12 @@ public class RemoteMoveFileCommand extends MoveFileCommand {
 	
 	
 	/**
-	 * Constructor which sets the two paths, source and destination,
-	 * to those given by the arguments of the constructor. See 
-	 * {@link org.eclipse.ice.tests.commands.MoveFileCommand} for member
-	 * variable descriptions.
-	 * @param src 
+	 * Constructor which sets the two paths, source and destination, to those given
+	 * by the arguments of the constructor. See
+	 * {@link org.eclipse.ice.tests.commands.MoveFileCommand} for member variable
+	 * descriptions.
+	 * 
+	 * @param src
 	 * @param dest
 	 */
 	public RemoteMoveFileCommand(String src, String dest) {

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteMoveFileCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteMoveFileCommand.java
@@ -25,9 +25,7 @@ public class RemoteMoveFileCommand extends MoveFileCommand {
 	/**
 	 * Default constructor
 	 */
-	public RemoteMoveFileCommand() {
-		
-	}
+	public RemoteMoveFileCommand() {}
 	
 	
 	/**
@@ -41,7 +39,6 @@ public class RemoteMoveFileCommand extends MoveFileCommand {
 	public RemoteMoveFileCommand(String src, String dest) {
 		source = Paths.get(src);
 		destination = Paths.get(dest);
-		status = execute();
 	}
 	
 

--- a/org.eclipse.ice.commands/src/main/resources/log4j.properties
+++ b/org.eclipse.ice.commands/src/main/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=DEBUG, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandConfigurationTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandConfigurationTest.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.ice.tests.commands;
 
-
 import static org.junit.Assert.fail;
 
 import org.junit.After;
@@ -57,7 +56,8 @@ public class CommandConfigurationTest {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.CommandConfiguration#CommandConfiguration()}.
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.CommandConfiguration#CommandConfiguration()}.
 	 */
 	@Test
 	public void testCommandConfiguration() {

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.ice.tests.commands;
 
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
@@ -96,14 +97,19 @@ public class CommandFactoryTest {
 		
 		
 		// Get the command
-		Command localCommand = CommandFactory.getCommand(commandConfig);
+		Command localCommand = null;
+		try {
+			localCommand = CommandFactory.getCommand(commandConfig);
+		} 
+		catch (IOException e) {
+			e.printStackTrace();
+		}
 		
 		// Run it
 		CommandStatus status = localCommand.execute();
 		
 		assert( status == CommandStatus.SUCCESS );
-		System.out.println("Status of functional command: " + status);
-		
+	
 	}
 	
 	
@@ -131,7 +137,13 @@ public class CommandFactoryTest {
 				2, executableDictionary, true );
 		
 		// Get the command
-		Command localCommand = CommandFactory.getCommand(commandConfig);
+		Command localCommand = null;
+		try {
+			localCommand = CommandFactory.getCommand(commandConfig);
+		} 
+		catch (IOException e) {
+			e.printStackTrace();
+		}
 						
 		// Run it and expect that it fails
 		CommandStatus status = localCommand.execute();
@@ -172,11 +184,15 @@ public class CommandFactoryTest {
 		
 		
 		// Get the command
-		Command localCommand2 = CommandFactory.getCommand(commandConfiguration);
+		Command localCommand2 = null;
+		try {
+			localCommand2 = CommandFactory.getCommand(commandConfiguration);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 		
 		// Run it and expect that it fails
 		CommandStatus status2 = localCommand2.execute();
-	
 		
 	}
 	

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.ice.tests.commands;
 
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -32,21 +31,20 @@ import org.junit.Test;
  */
 public class CommandFactoryTest {
 
-
 	/**
-	 * The hostname for which the job should run on. Default to local host name for now
+	 * The hostname for which the job should run on. Default to local host name for
+	 * now
 	 */
 	String hostname = getLocalHostname();
-	
 
 	/**
 	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#getCommand()}
-	 * and for the whole {@link org.eclipse.ice.commands.LocalCommand#execute()} 
+	 * and for the whole {@link org.eclipse.ice.commands.LocalCommand#execute()}
 	 * execution chain with a fully functional command dictionary
 	 */
-	
-	public CommandFactoryTest() {}
-	
+
+	public CommandFactoryTest() {
+	}
 
 	/**
 	 * @throws java.lang.Exception
@@ -54,137 +52,119 @@ public class CommandFactoryTest {
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 	}
-	
-	
+
 	@Test
 	public void testFunctionalLocalCommand() {
-		
-		
+
 		String hostname = getLocalHostname();
-		
+
 		/**
-		 * Create a HashMap which holds the executable instructions
-		 * Requirements for a Command to work:
-		 * executable - executable to be run
-		 * inputFile - input file, can set to "" if no input file
-		 * stdOutFileName - output file name
-		 * stdErrFileName - error file name
-		 * numProcs - number of processes
-		 * os - operating system to execute command on
-		 * workingDirectory - directory in which to execute the job
-		 * hostname - the hostname on which the job is to be hosted
+		 * Create a HashMap which holds the executable instructions Requirements for a
+		 * Command to work: executable - executable to be run inputFile - input file,
+		 * can set to "" if no input file stdOutFileName - output file name
+		 * stdErrFileName - error file name numProcs - number of processes os -
+		 * operating system to execute command on workingDirectory - directory in which
+		 * to execute the job hostname - the hostname on which the job is to be hosted
 		 */
 		/**
-		 * This is a test with real files to test an actual job processing.
-		 * For this test to work, make sure you change the workingDirectory
-		 * to your actual workingDirectory where the Commands API lives
+		 * This is a test with real files to test an actual job processing. For this
+		 * test to work, make sure you change the workingDirectory to your actual
+		 * workingDirectory where the Commands API lives
 		 */
-		
+
 		HashMap<String, String> executableDictionary = new HashMap<String, String>();
-		executableDictionary.put( "executable" , "./test_code_execution.sh" );
-		executableDictionary.put( "inputFile" , "someInputFile.txt" );
-		executableDictionary.put( "stdOutFileName",  "someOutFile.txt" );
-		executableDictionary.put( "stdErrFileName",  "someErrFile.txt" );
-		executableDictionary.put( "numProcs",  "1");
-		executableDictionary.put( "os",  "osx");
-		executableDictionary.put( "workingDirectory",  "/Users/4jo/git/icefork2/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands");
-		executableDictionary.put( "hostname", hostname);
-		
+		executableDictionary.put("executable", "./test_code_execution.sh");
+		executableDictionary.put("inputFile", "someInputFile.txt");
+		executableDictionary.put("stdOutFileName", "someOutFile.txt");
+		executableDictionary.put("stdErrFileName", "someErrFile.txt");
+		executableDictionary.put("numProcs", "1");
+		executableDictionary.put("os", "osx");
+		executableDictionary.put("workingDirectory",
+				"/Users/4jo/git/icefork2/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands");
+		executableDictionary.put("hostname", hostname);
+
 		// Set the CommandConfiguration class
-		CommandConfiguration commandConfig = new CommandConfiguration(
-				1, executableDictionary, true );
-		
-		
-		
+		CommandConfiguration commandConfig = new CommandConfiguration(1, executableDictionary, true);
+
 		// Get the command
 		Command localCommand = null;
 		try {
 			localCommand = CommandFactory.getCommand(commandConfig);
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		// Run it
 		CommandStatus status = localCommand.execute();
-		
-		assert( status == CommandStatus.SUCCESS );
-	
+
+		assert (status == CommandStatus.SUCCESS);
+
 	}
-	
-	
+
 	/**
 	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#getCommand()}
-	 * and for the whole {@link org.eclipse.ice.commands.LocalCommand#execute()} 
-	 * execution chain with an uncompleted Command dictionary. This is function is 
-	 * intended to test some of the exception catching, thus it is expected to "fail."
-	 * It expect a null pointer exception, since the hostname is not given and thus
-	 * the hostname string is null
+	 * and for the whole {@link org.eclipse.ice.commands.LocalCommand#execute()}
+	 * execution chain with an uncompleted Command dictionary. This is function is
+	 * intended to test some of the exception catching, thus it is expected to
+	 * "fail." It expect a null pointer exception, since the hostname is not given
+	 * and thus the hostname string is null
 	 */
 	@Test(expected = NullPointerException.class)
 	public void testNonFunctionalLocalCommand() {
-		
+
 		System.out.println("\nTesting some commands where not enough command information was provided.");
-	
-		
-		
+
 		// Create a HashMap that doesn't have all of the necessary ingredients
 		// a good job should have
 		HashMap<String, String> executableDictionary = new HashMap<String, String>();
-		executableDictionary.put( "executable" , "./test_code_execution.sh" );
-		
-		
+		executableDictionary.put("executable", "./test_code_execution.sh");
+
 		// Set the CommandConfiguration class
-		CommandConfiguration commandConfig = new CommandConfiguration(
-				2, executableDictionary, true );
-		
+		CommandConfiguration commandConfig = new CommandConfiguration(2, executableDictionary, true);
+
 		// Get the command
 		Command localCommand = null;
 		try {
 			localCommand = CommandFactory.getCommand(commandConfig);
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-						
+
 		// Run it and expect that it fails
 		CommandStatus status = localCommand.execute();
-						
-		assert( status == CommandStatus.INFOERROR );
-				
-		
+
+		assert (status == CommandStatus.INFOERROR);
+
 	}
-	
+
 	/**
 	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#getCommand()}
-	 * and for the whole {@link org.eclipse.ice.commands.LocalCommand#execute()} 
-	 * execution chain with an uncompleted Command dictionary. This function is 
-	 * intended to test some of the exception catching, thus it is expected to "fail."
+	 * and for the whole {@link org.eclipse.ice.commands.LocalCommand#execute()}
+	 * execution chain with an uncompleted Command dictionary. This function is
+	 * intended to test some of the exception catching, thus it is expected to
+	 * "fail."
 	 */
 	@Test
 	public void testIncorrectWorkingDirectory() {
 		/**
 		 * Run another non functional command, with a non existing working directory
 		 */
-		
+
 		System.out.println("\nTesting some commands where not enough command information was provided.");
-		
+
 		HashMap<String, String> executableDictionary = new HashMap<String, String>();
-		executableDictionary.put( "executable" , "./test_code_execution.sh" );
-		executableDictionary.put( "inputFile" , "someInputFile.txt" );
-		executableDictionary.put( "stdOutFileName",  "someOutFile.txt" );
-		executableDictionary.put( "stdErrFileName",  "someErrFile.txt" );
-		executableDictionary.put( "numProcs",  "1");
-		executableDictionary.put( "os",  "osx");
-		executableDictionary.put( "workingDirectory",  "~/some_nonexistant_directory");
-		executableDictionary.put( "hostname", hostname);
-		
+		executableDictionary.put("executable", "./test_code_execution.sh");
+		executableDictionary.put("inputFile", "someInputFile.txt");
+		executableDictionary.put("stdOutFileName", "someOutFile.txt");
+		executableDictionary.put("stdErrFileName", "someErrFile.txt");
+		executableDictionary.put("numProcs", "1");
+		executableDictionary.put("os", "osx");
+		executableDictionary.put("workingDirectory", "~/some_nonexistant_directory");
+		executableDictionary.put("hostname", hostname);
+
 		// Set the CommandConfiguration class
-		CommandConfiguration commandConfiguration = new CommandConfiguration(
-				1, executableDictionary, true );
-		
-		
-		
+		CommandConfiguration commandConfiguration = new CommandConfiguration(1, executableDictionary, true);
+
 		// Get the command
 		Command localCommand2 = null;
 		try {
@@ -192,20 +172,17 @@ public class CommandFactoryTest {
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		// Run it and expect that it fails
 		CommandStatus status2 = localCommand2.execute();
-		
-		assert( status2 == CommandStatus.FAILED);
+
+		assert (status2 == CommandStatus.FAILED);
 	}
-	
-	
-	
-	
-	
+
 	/**
-	 * This function just returns the local hostname of your local computer. 
-	 * It is useful for testing a variety of local commands.
+	 * This function just returns the local hostname of your local computer. It is
+	 * useful for testing a variety of local commands.
+	 * 
 	 * @return - String - local hostname
 	 */
 	protected String getLocalHostname() {
@@ -213,13 +190,12 @@ public class CommandFactoryTest {
 		InetAddress addr = null;
 		try {
 			addr = InetAddress.getLocalHost();
-		} 
-		catch (UnknownHostException e) {
+		} catch (UnknownHostException e) {
 			e.printStackTrace();
 		}
-				
+
 		String hostname = addr.getHostName();
-		
+
 		return hostname;
 	}
 

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
@@ -161,7 +161,7 @@ public class CommandFactoryTest {
 	 * execution chain with an uncompleted Command dictionary. This function is 
 	 * intended to test some of the exception catching, thus it is expected to "fail."
 	 */
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void testIncorrectWorkingDirectory() {
 		/**
 		 * Run another non functional command, with a non existing working directory

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandFactoryTest.java
@@ -117,9 +117,11 @@ public class CommandFactoryTest {
 	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#getCommand()}
 	 * and for the whole {@link org.eclipse.ice.commands.LocalCommand#execute()} 
 	 * execution chain with an uncompleted Command dictionary. This is function is 
-	 * intended to test some of the exception catching.
+	 * intended to test some of the exception catching, thus it is expected to "fail."
+	 * It expect a null pointer exception, since the hostname is not given and thus
+	 * the hostname string is null
 	 */
-	//@Test
+	@Test(expected = NullPointerException.class)
 	public void testNonFunctionalLocalCommand() {
 		
 		System.out.println("\nTesting some commands where not enough command information was provided.");
@@ -157,9 +159,9 @@ public class CommandFactoryTest {
 	 * Test method for {@link org.eclipse.ice.commands.CommandFactory#getCommand()}
 	 * and for the whole {@link org.eclipse.ice.commands.LocalCommand#execute()} 
 	 * execution chain with an uncompleted Command dictionary. This function is 
-	 * intended to test some of the exception catching.
+	 * intended to test some of the exception catching, thus it is expected to "fail."
 	 */
-	//@Test
+	@Test(expected = NullPointerException.class)
 	public void testIncorrectWorkingDirectory() {
 		/**
 		 * Run another non functional command, with a non existing working directory
@@ -194,6 +196,7 @@ public class CommandFactoryTest {
 		// Run it and expect that it fails
 		CommandStatus status2 = localCommand2.execute();
 		
+		assert( status2 == CommandStatus.FAILED);
 	}
 	
 	

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandStatusTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandStatusTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 /**
  * This class tests {@link org.eclipse.ice.commands.CommandStatus}.
+ * 
  * @author Joe Osborn
  *
  */
@@ -56,7 +57,8 @@ public class CommandStatusTest {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.CommandStatus#CommandStatus()}.
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.CommandStatus#CommandStatus()}.
 	 */
 	@Test
 	public void testCommandStatus() {

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CommandTest.java
@@ -23,65 +23,64 @@ import org.junit.Test;
 
 /**
  * Test for class {@link org.eclipse.ice.commands.Command}.
+ * 
  * @author Joe Osborn
  *
  */
 public class CommandTest {
 
-	
 	/**
 	 * Test method for {@link org.eclipse.ice.commands.Command#Command()}
 	 */
 	@Test
 	public void testLocalCommand() {
-	
+
 		// Use the already defined function in CommandFactoryTest to get the
 		// local hostname
 		CommandFactoryTest commandFactory = new CommandFactoryTest();
 		String hostname = commandFactory.getLocalHostname();
-		
+
 		HashMap<String, String> executableDictionary = new HashMap<String, String>();
-		executableDictionary.put( "executable" , "./test_code_execution.sh" );
-		executableDictionary.put( "inputFile" , "someInputFile.txt" );
-		executableDictionary.put( "stdOutFileName",  "someOutFile.txt" );
-		executableDictionary.put( "stdErrFileName",  "someErrFile.txt" );
-		executableDictionary.put( "numProcs",  "1");
-		executableDictionary.put( "os",  "osx");
-		executableDictionary.put( "workingDirectory", "/Users/4jo/git/icefork2/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands");
-		executableDictionary.put( "hostname", hostname);
-		
+		executableDictionary.put("executable", "./test_code_execution.sh");
+		executableDictionary.put("inputFile", "someInputFile.txt");
+		executableDictionary.put("stdOutFileName", "someOutFile.txt");
+		executableDictionary.put("stdErrFileName", "someErrFile.txt");
+		executableDictionary.put("numProcs", "1");
+		executableDictionary.put("os", "osx");
+		executableDictionary.put("workingDirectory",
+				"/Users/4jo/git/icefork2/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands");
+		executableDictionary.put("hostname", hostname);
+
 		// Set the CommandConfiguration class
-		CommandConfiguration commandConfig = new CommandConfiguration(
-				1, executableDictionary, true );
-		
+		CommandConfiguration commandConfig = new CommandConfiguration(1, executableDictionary, true);
+
 		Command localCommand = new LocalCommand(commandConfig);
 		CommandStatus status = localCommand.execute();
-		
+
 		System.out.println("Command finished with: " + status);
-		assert( status == CommandStatus.SUCCESS );
-		
+		assert (status == CommandStatus.SUCCESS);
+
 	}
-	
+
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.Command#checkStatus(CommandStatus)}
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.Command#checkStatus(CommandStatus)}
 	 */
-	//@Test
+	// @Test
 	public void testCheckStatus() {
-		
+
 		System.out.println("\nTesting that Command::CheckStatus throws an exception for a bad status");
 		// Create instances of a command and associated status
 		CommandStatus status = CommandStatus.INFOERROR;
 		Command command = new LocalCommand();
-		
+
 		// Check to make sure that an exception is thrown for a bad status
 		try {
 			command.checkStatus(status);
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 	}
-	
-	
+
 }

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionManagerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/ConnectionManagerTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 /**
  * Test for class {@link org.eclipse.ice.commands.ConnectionManager}.
+ * 
  * @author Joe Osborn
  *
  */
@@ -60,37 +61,40 @@ public class ConnectionManagerTest {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.ConnectionManager#ConnectionManager()}
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.ConnectionManager#ConnectionManager()}
 	 */
 	public void testConnectionManager() {
 		fail("Not yet implemented");
 	}
-	
+
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.ConnectionManager#OpenConnection(String)}
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.ConnectionManager#OpenConnection(String)}
 	 */
 	public void testOpenConnection() {
 		fail("Not yet implemented");
 	}
-	
-	
+
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.ConnectionManager#GetConnection(String)}
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.ConnectionManager#GetConnection(String)}
 	 */
 	public void testGetConnection() {
 		fail("Not yet implemented");
 	}
-	
-	
+
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.ConnectionManager#CloseConnection(String)}
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.ConnectionManager#CloseConnection(String)}
 	 */
 	public void testCloseConnection() {
 		fail("Not yet implemented");
 	}
-	
+
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.ConnectionManager#CloseAllConnections()}
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.ConnectionManager#CloseAllConnections()}
 	 */
 	public void testCloseAllConnection() {
 		fail("Not yet implemented");

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CopyFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/CopyFileCommandTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 /**
  * Test for class {@link org.eclipse.ice.commands.CopyFileCommand}.
+ * 
  * @author Joe Osborn
  *
  */
@@ -58,11 +59,11 @@ public class CopyFileCommandTest {
 	public void test() {
 		fail("Not yet implemented");
 	}
-	
+
 	/**
 	 * Test method for{@link org.eclipse.ice.commands.CopyFileCommand()}
 	 */
-	
+
 	public void testCopyFileCommand() {
 		fail("Not yet implemented");
 	}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/FileHandlerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/FileHandlerTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 /**
  * This class tests {@link org.eclipse.ice.commands.FileHandler}.
+ * 
  * @author Jay Jay Billings, Joe Osborn
  *
  */
@@ -33,24 +34,24 @@ public class FileHandlerTest {
 
 	String localSource = null;
 	String localDestination = null;
-	
+
 	/**
 	 * Set up some dummy local files to work with
+	 * 
 	 * @throws java.lang.Exception
 	 */
 	@Before
 	public void setUp() throws Exception {
-		
-		// First create a dummy text file to test 
+
+		// First create a dummy text file to test
 		String source = "dummyfile.txt";
 		Path sourcePath = null;
 		try {
 			sourcePath = Files.createTempFile(null, source);
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-				
+
 		// Turn the path into a string to pass to the command
 		localSource = sourcePath.toString();
 		System.out.println("Created source file at: " + localSource);
@@ -59,119 +60,102 @@ public class FileHandlerTest {
 		String dest = "testCopyDirectory";
 		try {
 			destinationPath = Files.createTempDirectory(dest);
-		}
-		catch(IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-				
+
 		// Turn the path into a string to give to the command
 		localDestination = destinationPath.toString();
 		System.out.println("Created destination file at: " + localDestination);
 	}
 
-	
 	/**
 	 * Deletes the temporarily made files since they are not useful
+	 * 
 	 * @throws java.lang.Exception
 	 */
 	@After
 	public void tearDown() throws Exception {
 		System.out.println("Delete temporary files/directories that were created.");
-		
+
 		// Get the paths
 		Path sourcePath = Paths.get(localSource);
 		Path destPath = Paths.get(localDestination);
-		
+
 		// Delete the files
 		try {
 			Files.deleteIfExists(sourcePath);
-		}
-		catch (NoSuchFileException e) {
-		    System.err.format("%s: no such" + " file or directory%n", sourcePath);
-		    e.printStackTrace();
-		} 
-		catch (DirectoryNotEmptyException e) {
-		    System.err.format("%s not empty%n", sourcePath);
-		    e.printStackTrace();
-		} 
-		catch (IOException e) {
-		    System.err.println(e);
-		    e.printStackTrace();
+		} catch (NoSuchFileException e) {
+			System.err.format("%s: no such" + " file or directory%n", sourcePath);
+			e.printStackTrace();
+		} catch (DirectoryNotEmptyException e) {
+			System.err.format("%s not empty%n", sourcePath);
+			e.printStackTrace();
+		} catch (IOException e) {
+			System.err.println(e);
+			e.printStackTrace();
 		}
 		try {
 			Files.deleteIfExists(destPath);
-		}
-		catch (NoSuchFileException e) {
-		    System.err.format("%s: no such" + " file or directory%n", destPath);
-		    e.printStackTrace();
-		} 
-		catch (DirectoryNotEmptyException e) {
-		    // If the directory is not empty, that is because it was a move command
+		} catch (NoSuchFileException e) {
+			System.err.format("%s: no such" + " file or directory%n", destPath);
+			e.printStackTrace();
+		} catch (DirectoryNotEmptyException e) {
+			// If the directory is not empty, that is because it was a move command
 			// and the moved file is in there. So delete the file first and then
 			// delete the directory
-			
+
 			// Need to get the filename individually
 			String delims = "[/]";
 			String[] tokens = localSource.split(delims);
-			String filename = tokens[tokens.length-1];
-			
+			String filename = tokens[tokens.length - 1];
+
 			// Make the destination path + the filename
 			String fullDestination = localDestination + "/" + filename;
-			
 
 			// Get the paths
 			Path destFile = Paths.get(fullDestination);
 			Path destDir = Paths.get(localDestination);
-			
+
 			// Try to delete the destination file. If it can't be deleted, then
 			// there is really a problem now and it will complain
 			try {
 				Files.deleteIfExists(destFile);
+			} catch (NoSuchFileException e1) {
+				System.err.format("%s: no such" + " file or directory%n", destFile);
+				e1.printStackTrace();
+			} catch (DirectoryNotEmptyException e1) {
+				System.err.format("%s not empty%n", destFile);
+				e1.printStackTrace();
+			} catch (IOException e1) {
+				System.err.println(e1);
+				e1.printStackTrace();
 			}
-			catch (NoSuchFileException e1) {
-			    System.err.format("%s: no such" + " file or directory%n", destFile);
-			    e1.printStackTrace();
-			} 
-			catch (DirectoryNotEmptyException e1) {
-			    System.err.format("%s not empty%n", destFile);
-			    e1.printStackTrace();
-			} 
-			catch (IOException e1) {
-			    System.err.println(e1);
-			    e1.printStackTrace();
-			}
-			
+
 			// Try to delete the destination directory. If it can't be deleted, then
 			// there is really a problem now and it will complain
 			try {
 				Files.deleteIfExists(destDir);
+			} catch (NoSuchFileException e1) {
+				System.err.format("%s: no such" + " file or directory%n", destDir);
+				e1.printStackTrace();
+			} catch (DirectoryNotEmptyException e1) {
+				System.err.format("%s not empty%n", destDir);
+				e1.printStackTrace();
+			} catch (IOException e1) {
+				System.err.println(e);
+				e1.printStackTrace();
 			}
-			catch (NoSuchFileException e1) {
-			    System.err.format("%s: no such" + " file or directory%n", destDir);
-			    e1.printStackTrace();
-			} 
-			catch (DirectoryNotEmptyException e1) {
-			    System.err.format("%s not empty%n", destDir);
-			    e1.printStackTrace();
-			} 
-			catch (IOException e1) {
-			    System.err.println(e);
-			    e1.printStackTrace();
-			}
-			
-		} 
-		catch (IOException e) {
-		    System.err.println(e);
-		    e.printStackTrace();
+
+		} catch (IOException e) {
+			System.err.println(e);
+			e.printStackTrace();
 		}
 	}
-	
-	
-	
-	
-	
+
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.FileHandler#copy(java.lang.String, java.lang.String)}.
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.FileHandler#copy(java.lang.String, java.lang.String)}.
 	 */
 	@Test
 	public void testLocalCopy() {
@@ -179,24 +163,23 @@ public class FileHandlerTest {
 		try {
 			Command copy = FileHandler.copy(localSource, localDestination);
 			copy.execute();
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		// Check that it exists
 		try {
 			boolean exist = FileHandler.exists(localDestination);
-			assert( exist == true );
-		} 
-		catch (IOException e) {
+			assert (exist == true);
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
 		System.out.println("Finished testing testLocalCopy() function.");
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.FileHandler#move(java.lang.String, java.lang.String)}.
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.FileHandler#move(java.lang.String, java.lang.String)}.
 	 */
 	@Test
 	public void testLocalMove() {
@@ -204,55 +187,47 @@ public class FileHandlerTest {
 		try {
 			Command move = FileHandler.move(localSource, localDestination);
 			move.execute();
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		// Check that it exists
-		try { 
+		try {
 			boolean exist = FileHandler.exists(localDestination);
-			assert( exist == true );
-		}
-		catch (IOException e) {
+			assert (exist == true);
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		System.out.println("Finished testing testLocalMove() function.");
-		
+
 	}
 
-
-
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.FileHandler#exists(java.lang.String)}.
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.FileHandler#exists(java.lang.String)}.
 	 */
 	@Test
 	public void testExists() {
 		System.out.println("Testing testExists() function.");
-		
+
 		/**
 		 * Test a file that everyone should have existing
 		 */
 		try {
-			assert(FileHandler.exists("/usr/lib/python2.7"));
-		} 
-		catch (IOException e) {
+			assert (FileHandler.exists("/usr/lib/python2.7"));
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		System.out.println("Testing testExists() with a non existing file");
 		try {
-			assert(!FileHandler.exists("/usr/file_that_doesnot_exist.txt"));
-		}
-		catch (IOException e) {
+			assert (!FileHandler.exists("/usr/file_that_doesnot_exist.txt"));
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		System.out.println("Finished testing testExists()");
 	}
 
-	
-	
-	
 }

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/FileHandlerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/FileHandlerTest.java
@@ -11,8 +11,6 @@
  *******************************************************************************/
 package org.eclipse.ice.tests.commands;
 
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
@@ -20,6 +18,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.eclipse.ice.commands.Command;
 import org.eclipse.ice.commands.FileHandler;
 import org.junit.After;
 import org.junit.Before;
@@ -77,6 +76,7 @@ public class FileHandlerTest {
 	 */
 	@After
 	public void tearDown() throws Exception {
+		System.out.println("Delete temporary files/directories that were created.");
 		
 		// Get the paths
 		Path sourcePath = Paths.get(localSource);
@@ -167,13 +167,7 @@ public class FileHandlerTest {
 	}
 	
 	
-	/**
-	 * Test method for {@link org.eclipse.ice.commands.FileHandler#FileHandler()}.
-	 */
-	//@Test
-	public void testFileHandler() {
-		fail("Not yet implemented");
-	}
+	
 	
 	
 	/**
@@ -183,7 +177,8 @@ public class FileHandlerTest {
 	public void testLocalCopy() {
 		System.out.println("Testing testLocalCopy() function.");
 		try {
-			FileHandler.copy(localSource, localDestination+"copy");
+			Command copy = FileHandler.copy(localSource, localDestination);
+			copy.execute();
 		} 
 		catch (IOException e) {
 			e.printStackTrace();
@@ -191,7 +186,8 @@ public class FileHandlerTest {
 		
 		// Check that it exists
 		try {
-			FileHandler.exists(localDestination);
+			boolean exist = FileHandler.exists(localDestination);
+			assert( exist == true );
 		} 
 		catch (IOException e) {
 			e.printStackTrace();
@@ -206,7 +202,8 @@ public class FileHandlerTest {
 	public void testLocalMove() {
 		System.out.println("Testing testLocalMove() function.");
 		try {
-			FileHandler.move(localSource, localDestination);
+			Command move = FileHandler.move(localSource, localDestination);
+			move.execute();
 		} 
 		catch (IOException e) {
 			e.printStackTrace();
@@ -214,7 +211,8 @@ public class FileHandlerTest {
 		
 		// Check that it exists
 		try { 
-			FileHandler.exists(localDestination);
+			boolean exist = FileHandler.exists(localDestination);
+			assert( exist == true );
 		}
 		catch (IOException e) {
 			e.printStackTrace();

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/FileHandlerTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/FileHandlerTest.java
@@ -14,10 +14,14 @@ package org.eclipse.ice.tests.commands;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.eclipse.ice.commands.FileHandler;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,7 +54,7 @@ public class FileHandlerTest {
 				
 		// Turn the path into a string to pass to the command
 		localSource = sourcePath.toString();
-				
+		System.out.println("Created source file at: " + localSource);
 		// Do the same for the destination
 		Path destinationPath = null;
 		String dest = "testCopyDirectory";
@@ -63,9 +67,106 @@ public class FileHandlerTest {
 				
 		// Turn the path into a string to give to the command
 		localDestination = destinationPath.toString();
-		
+		System.out.println("Created destination file at: " + localDestination);
 	}
 
+	
+	/**
+	 * Deletes the temporarily made files since they are not useful
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+		
+		// Get the paths
+		Path sourcePath = Paths.get(localSource);
+		Path destPath = Paths.get(localDestination);
+		
+		// Delete the files
+		try {
+			Files.deleteIfExists(sourcePath);
+		}
+		catch (NoSuchFileException e) {
+		    System.err.format("%s: no such" + " file or directory%n", sourcePath);
+		    e.printStackTrace();
+		} 
+		catch (DirectoryNotEmptyException e) {
+		    System.err.format("%s not empty%n", sourcePath);
+		    e.printStackTrace();
+		} 
+		catch (IOException e) {
+		    System.err.println(e);
+		    e.printStackTrace();
+		}
+		try {
+			Files.deleteIfExists(destPath);
+		}
+		catch (NoSuchFileException e) {
+		    System.err.format("%s: no such" + " file or directory%n", destPath);
+		    e.printStackTrace();
+		} 
+		catch (DirectoryNotEmptyException e) {
+		    // If the directory is not empty, that is because it was a move command
+			// and the moved file is in there. So delete the file first and then
+			// delete the directory
+			
+			// Need to get the filename individually
+			String delims = "[/]";
+			String[] tokens = localSource.split(delims);
+			String filename = tokens[tokens.length-1];
+			
+			// Make the destination path + the filename
+			String fullDestination = localDestination + "/" + filename;
+			
+
+			// Get the paths
+			Path destFile = Paths.get(fullDestination);
+			Path destDir = Paths.get(localDestination);
+			
+			// Try to delete the destination file. If it can't be deleted, then
+			// there is really a problem now and it will complain
+			try {
+				Files.deleteIfExists(destFile);
+			}
+			catch (NoSuchFileException e1) {
+			    System.err.format("%s: no such" + " file or directory%n", destFile);
+			    e1.printStackTrace();
+			} 
+			catch (DirectoryNotEmptyException e1) {
+			    System.err.format("%s not empty%n", destFile);
+			    e1.printStackTrace();
+			} 
+			catch (IOException e1) {
+			    System.err.println(e1);
+			    e1.printStackTrace();
+			}
+			
+			// Try to delete the destination directory. If it can't be deleted, then
+			// there is really a problem now and it will complain
+			try {
+				Files.deleteIfExists(destDir);
+			}
+			catch (NoSuchFileException e1) {
+			    System.err.format("%s: no such" + " file or directory%n", destDir);
+			    e1.printStackTrace();
+			} 
+			catch (DirectoryNotEmptyException e1) {
+			    System.err.format("%s not empty%n", destDir);
+			    e1.printStackTrace();
+			} 
+			catch (IOException e1) {
+			    System.err.println(e);
+			    e1.printStackTrace();
+			}
+			
+		} 
+		catch (IOException e) {
+		    System.err.println(e);
+		    e.printStackTrace();
+		}
+	}
+	
+	
 	/**
 	 * Test method for {@link org.eclipse.ice.commands.FileHandler#FileHandler()}.
 	 */

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCommandTest.java
@@ -21,83 +21,71 @@ import org.junit.Test;
 
 /**
  * Test for class {@link org.eclipse.ice.commands.LocalCommand}.
+ * 
  * @author Joe Osborn
  *
  */
 public class LocalCommandTest {
 
 	HashMap<String, String> executableDictionary;
-	
-	
 
 	/**
 	 * @throws java.lang.Exception
 	 */
 	@Before
 	public void setUp() throws Exception {
-		
+
 		// Set up some default instance variables
 		executableDictionary = new HashMap<String, String>();
-		executableDictionary.put( "executable" , "someExecutable.sh ${installDir}" );
-		executableDictionary.put( "inputFile" , "someInputFile.txt" );
-		executableDictionary.put( "stdOutFileName",  "someOutFile.txt" );
-		executableDictionary.put( "stdErrFileName",  "someErrFile.txt" );
-		executableDictionary.put( "installDir" ,  "~/install");
-		executableDictionary.put( "numProcs",  "1");
-		executableDictionary.put( "os",  "OSX");
-		executableDictionary.put( "workingDirectory", "/");
+		executableDictionary.put("executable", "someExecutable.sh ${installDir}");
+		executableDictionary.put("inputFile", "someInputFile.txt");
+		executableDictionary.put("stdOutFileName", "someOutFile.txt");
+		executableDictionary.put("stdErrFileName", "someErrFile.txt");
+		executableDictionary.put("installDir", "~/install");
+		executableDictionary.put("numProcs", "1");
+		executableDictionary.put("os", "OSX");
+		executableDictionary.put("workingDirectory", "/");
 	}
 
-
-	
-	
-	
 	/**
-	 * Test for method {@link org.eclipse.ice.commands.LocalCommand()}
-	 * Tests check for proper configuration and checking of the LocalCommand
-	 * member variables so that the Command can actually be run. 
+	 * Test for method {@link org.eclipse.ice.commands.LocalCommand()} Tests check
+	 * for proper configuration and checking of the LocalCommand member variables so
+	 * that the Command can actually be run.
 	 */
 	@Test
 	public void testLocalCommand() {
-		
+
 		System.out.println("Starting testLocalCommand");
-	
+
 		// Now make a "real" command configuration to test
-		CommandConfiguration commandConfig = new CommandConfiguration(
-				3, executableDictionary, true );
-		
+		CommandConfiguration commandConfig = new CommandConfiguration(3, executableDictionary, true);
+
 		LocalCommand realCommand = new LocalCommand(commandConfig);
 		CommandStatus testStatus = realCommand.getStatus();
-		
-		
-		assert( testStatus == CommandStatus.RUNNING );
-		System.out.println("Finished testConfiguration\n");	
-	
+
+		assert (testStatus == CommandStatus.RUNNING);
+		System.out.println("Finished testConfiguration\n");
+
 	}
-	
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.LocalCommand#Execute()}. This test should
-	 * "fail" by default since the CommandConfiguration executableDictionary does not point
-	 * to a real executable. This is a test of the API catching an incorrectly configured
-	 * command.
-	 * For a test of a fully functional command, see {@link org.eclipse.ice.commands.testCommandFactory()}
+	 * Test method for {@link org.eclipse.ice.commands.LocalCommand#Execute()}. This
+	 * test should "fail" by default since the CommandConfiguration
+	 * executableDictionary does not point to a real executable. This is a test of
+	 * the API catching an incorrectly configured command. For a test of a fully
+	 * functional command, see {@link org.eclipse.ice.commands.testCommandFactory()}
 	 */
 	@Test
 	public void testExecute() {
 		System.out.println("Starting testExecute\n");
-		
-		LocalCommand testCommand = new LocalCommand(new CommandConfiguration(2,
-				executableDictionary, true));
-		
+
+		LocalCommand testCommand = new LocalCommand(new CommandConfiguration(2, executableDictionary, true));
+
 		CommandStatus testStatus = testCommand.execute();
 
-		assert ( testStatus == CommandStatus.FAILED );
+		assert (testStatus == CommandStatus.FAILED);
 		System.out.println("Example incorrect executable status should be FAILED and is: " + testStatus);
 		System.out.println("Finished testExecute\n");
 	}
-	
-	
-	
-	
+
 }

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCopyFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCopyFileCommandTest.java
@@ -161,7 +161,7 @@ public class LocalCopyFileCommandTest {
 		// Make the command
 		LocalCopyFileCommand command = 
 				new LocalCopyFileCommand(source, dest);
-		
+		command.execute();
 		// Check if the path exists now
 		Path path = Paths.get(dest);
 		assert(Files.exists(path));

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCopyFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCopyFileCommandTest.java
@@ -12,11 +12,14 @@
 package org.eclipse.ice.tests.commands;
 
 import java.io.IOException;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.eclipse.ice.commands.LocalCopyFileCommand;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,12 +34,12 @@ public class LocalCopyFileCommandTest {
 	/**
 	 * A source file that is created for testing
 	 */
-	String source;
+	String source = null;
 	
 	/**
 	 * A destination path that is created for testing 
 	 */
-	String dest;
+	String dest = null;
 	
 	/**
 	 * This function sets up and creates a dummy test file for 
@@ -75,6 +78,76 @@ public class LocalCopyFileCommandTest {
 		dest = destinationPath.toString();
 	}
 
+	/**
+	 * Deletes the temporarily made files since they are not useful
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+		
+		// Get the individual directories
+		String delims = "[/]";
+		String[] tokens = source.split(delims);
+		String filename = tokens[tokens.length-1];
+		
+		// Make the destination path + the filename
+		String fullDestination = dest + "/" + filename;
+		
+		// Get the paths
+		Path sourcePath = Paths.get(source);
+		Path destPath = Paths.get(fullDestination);
+		Path destDirectory = Paths.get(dest);
+		
+		// Delete the files
+		try {
+			Files.deleteIfExists(sourcePath);
+		}
+		catch (NoSuchFileException e) {
+		    System.err.format("%s: no such" + " file or directory%n", sourcePath);
+		    e.printStackTrace();
+		} 
+		catch (DirectoryNotEmptyException e) {
+		    System.err.format("%s not empty%n", sourcePath);
+		    e.printStackTrace();
+		} 
+		catch (IOException e) {
+		    System.err.println(e);
+		    e.printStackTrace();
+		}
+		try {
+			Files.deleteIfExists(destPath);
+		}
+		catch (NoSuchFileException e) {
+		    System.err.format("%s: no such" + " file or directory%n", destPath);
+		    e.printStackTrace();
+		} 
+		catch (DirectoryNotEmptyException e) {
+		    System.err.format("%s not empty%n", destPath);
+		    e.printStackTrace();
+		} 
+		catch (IOException e) {
+		    System.err.println(e);
+		    e.printStackTrace();
+		}
+		try {
+			Files.deleteIfExists(destDirectory);
+		}
+		catch (NoSuchFileException e) {
+		    System.err.format("%s: no such" + " file or directory%n", destDirectory);
+		    e.printStackTrace();
+		} 
+		catch (DirectoryNotEmptyException e) {
+		    System.err.format("%s not empty%n", destDirectory);
+		    e.printStackTrace();
+		} 
+		catch (IOException e) {
+		    System.err.println(e);
+		    e.printStackTrace();
+		}
+		
+	}
+	
+	
 	/**
 	 * Test method for {@link org.eclipse.ice.commands.LocalCopyFileCommand#LocalCopyFileCommand(String, String)}
 	 * 

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCopyFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalCopyFileCommandTest.java
@@ -23,10 +23,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-
 /**
  * Test for class {@link org.eclipse.ice.commands.LocalCommand}.
- * @author Joe Osborn 
+ * 
+ * @author Joe Osborn
  *
  */
 public class LocalCopyFileCommandTest {
@@ -35,15 +35,16 @@ public class LocalCopyFileCommandTest {
 	 * A source file that is created for testing
 	 */
 	String source = null;
-	
+
 	/**
-	 * A destination path that is created for testing 
+	 * A destination path that is created for testing
 	 */
 	String dest = null;
-	
+
 	/**
-	 * This function sets up and creates a dummy test file for 
-	 * the testing of the class {@link org.eclipse.ice.commands.LocalCopyFileCommand#LocalCopyFileCommand(String, String)}
+	 * This function sets up and creates a dummy test file for the testing of the
+	 * class
+	 * {@link org.eclipse.ice.commands.LocalCopyFileCommand#LocalCopyFileCommand(String, String)}
 	 * 
 	 * @throws java.lang.Exception
 	 */
@@ -51,120 +52,107 @@ public class LocalCopyFileCommandTest {
 	public void setUp() throws Exception {
 		// Set a dummy source and destination to copy
 
-		// First create a dummy text file to test 
+		// First create a dummy text file to test
 		source = "dummyfile.txt";
 		Path sourcePath = null;
 		try {
 			sourcePath = Files.createTempFile(null, source);
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-				
+
 		// Turn the path into a string to pass to the command
 		source = sourcePath.toString();
-				
+
 		// Do the same for the destination
 		Path destinationPath = null;
 		dest = "testCopyDirectory";
 		try {
 			destinationPath = Files.createTempDirectory(dest);
-		}
-		catch(IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-				
+
 		// Turn the path into a string to give to the command
 		dest = destinationPath.toString();
 	}
 
 	/**
 	 * Deletes the temporarily made files since they are not useful
+	 * 
 	 * @throws java.lang.Exception
 	 */
 	@After
 	public void tearDown() throws Exception {
-		
+
 		// Get the individual directories
 		String delims = "[/]";
 		String[] tokens = source.split(delims);
-		String filename = tokens[tokens.length-1];
-		
+		String filename = tokens[tokens.length - 1];
+
 		// Make the destination path + the filename
 		String fullDestination = dest + "/" + filename;
-		
+
 		// Get the paths
 		Path sourcePath = Paths.get(source);
 		Path destPath = Paths.get(fullDestination);
 		Path destDirectory = Paths.get(dest);
-		
+
 		// Delete the files
 		try {
 			Files.deleteIfExists(sourcePath);
-		}
-		catch (NoSuchFileException e) {
-		    System.err.format("%s: no such" + " file or directory%n", sourcePath);
-		    e.printStackTrace();
-		} 
-		catch (DirectoryNotEmptyException e) {
-		    System.err.format("%s not empty%n", sourcePath);
-		    e.printStackTrace();
-		} 
-		catch (IOException e) {
-		    System.err.println(e);
-		    e.printStackTrace();
+		} catch (NoSuchFileException e) {
+			System.err.format("%s: no such" + " file or directory%n", sourcePath);
+			e.printStackTrace();
+		} catch (DirectoryNotEmptyException e) {
+			System.err.format("%s not empty%n", sourcePath);
+			e.printStackTrace();
+		} catch (IOException e) {
+			System.err.println(e);
+			e.printStackTrace();
 		}
 		try {
 			Files.deleteIfExists(destPath);
-		}
-		catch (NoSuchFileException e) {
-		    System.err.format("%s: no such" + " file or directory%n", destPath);
-		    e.printStackTrace();
-		} 
-		catch (DirectoryNotEmptyException e) {
-		    System.err.format("%s not empty%n", destPath);
-		    e.printStackTrace();
-		} 
-		catch (IOException e) {
-		    System.err.println(e);
-		    e.printStackTrace();
+		} catch (NoSuchFileException e) {
+			System.err.format("%s: no such" + " file or directory%n", destPath);
+			e.printStackTrace();
+		} catch (DirectoryNotEmptyException e) {
+			System.err.format("%s not empty%n", destPath);
+			e.printStackTrace();
+		} catch (IOException e) {
+			System.err.println(e);
+			e.printStackTrace();
 		}
 		try {
 			Files.deleteIfExists(destDirectory);
+		} catch (NoSuchFileException e) {
+			System.err.format("%s: no such" + " file or directory%n", destDirectory);
+			e.printStackTrace();
+		} catch (DirectoryNotEmptyException e) {
+			System.err.format("%s not empty%n", destDirectory);
+			e.printStackTrace();
+		} catch (IOException e) {
+			System.err.println(e);
+			e.printStackTrace();
 		}
-		catch (NoSuchFileException e) {
-		    System.err.format("%s: no such" + " file or directory%n", destDirectory);
-		    e.printStackTrace();
-		} 
-		catch (DirectoryNotEmptyException e) {
-		    System.err.format("%s not empty%n", destDirectory);
-		    e.printStackTrace();
-		} 
-		catch (IOException e) {
-		    System.err.println(e);
-		    e.printStackTrace();
-		}
-		
+
 	}
-	
-	
+
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.LocalCopyFileCommand#LocalCopyFileCommand(String, String)}
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.LocalCopyFileCommand#LocalCopyFileCommand(String, String)}
 	 * 
 	 */
 	@Test
 	public void testLocalCopyFileCommand() {
-		
-		
-		
+
 		System.out.println("Copying: " + source + " to destination: " + dest);
 		// Make the command
-		LocalCopyFileCommand command = 
-				new LocalCopyFileCommand(source, dest);
+		LocalCopyFileCommand command = new LocalCopyFileCommand(source, dest);
 		command.execute();
 		// Check if the path exists now
 		Path path = Paths.get(dest);
-		assert(Files.exists(path));
-		
+		assert (Files.exists(path));
+
 	}
 }

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalMoveFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalMoveFileCommandTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 /**
  * Test for class {@link org.eclipse.ice.commands.LocalMoveFileCommand}.
+ * 
  * @author Joe Osborn
  *
  */
@@ -34,15 +35,16 @@ public class LocalMoveFileCommandTest {
 	 * A source file that is created for testing
 	 */
 	String source = null;
-	
+
 	/**
-	 * A destination path that is created for testing 
+	 * A destination path that is created for testing
 	 */
 	String dest = null;
-	
+
 	/**
-	 * This function sets up and creates a dummy test file for 
-	 * the testing of the class {@link org.eclipse.ice.commands.LocalMoveFileCommand#LocalMoveFileCommand(String, String)}
+	 * This function sets up and creates a dummy test file for the testing of the
+	 * class
+	 * {@link org.eclipse.ice.commands.LocalMoveFileCommand#LocalMoveFileCommand(String, String)}
 	 * 
 	 * @throws java.lang.Exception
 	 */
@@ -50,56 +52,51 @@ public class LocalMoveFileCommandTest {
 	public void setUp() throws Exception {
 		// Set a dummy source and destination to copy
 
-		// First create a dummy text file to test 
+		// First create a dummy text file to test
 		source = "dummyfile.txt";
 		Path sourcePath = null;
 		try {
 			sourcePath = Files.createTempFile(null, source);
-		} 
-		catch (IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-				
+
 		// Turn the path into a string to pass to the command
 		source = sourcePath.toString();
-				
+
 		// Do the same for the destination
 		Path destinationPath = null;
 		dest = "testCopyDirectory";
 		try {
 			destinationPath = Files.createTempDirectory(dest);
-		}
-		catch(IOException e) {
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
-				
+
 		// Turn the path into a string to give to the command
 		dest = destinationPath.toString();
 	}
-	
-	
-	
+
 	/**
 	 * Deletes the temporarily made files since they are not useful
+	 * 
 	 * @throws java.lang.Exception
 	 */
 	@After
 	public void tearDown() throws Exception {
-		
+
 		// Need to get the filename individually
 		String delims = "[/]";
 		String[] tokens = source.split(delims);
-		String filename = tokens[tokens.length-1];
-		
+		String filename = tokens[tokens.length - 1];
+
 		// Make the destination path + the filename
 		String fullDestination = dest + "/" + filename;
-		
 
 		// Get the paths
 		Path destFile = Paths.get(fullDestination);
 		Path destDir = Paths.get(dest);
-		
-		
+
 		// Delete the files
 		// Only need to delete the moved file and destination directory,
 		// since the source file was created in the default system directory
@@ -107,56 +104,47 @@ public class LocalMoveFileCommandTest {
 		// exist in the original directory
 		try {
 			Files.deleteIfExists(destFile);
+		} catch (NoSuchFileException e) {
+			System.err.format("%s: no such" + " file or directory%n", destFile);
+			e.printStackTrace();
+		} catch (DirectoryNotEmptyException e) {
+			System.err.format("%s not empty%n", destFile);
+			e.printStackTrace();
+		} catch (IOException e) {
+			System.err.println(e);
+			e.printStackTrace();
 		}
-		catch (NoSuchFileException e) {
-		    System.err.format("%s: no such" + " file or directory%n", destFile);
-		    e.printStackTrace();
-		} 
-		catch (DirectoryNotEmptyException e) {
-		    System.err.format("%s not empty%n", destFile);
-		    e.printStackTrace();
-		} 
-		catch (IOException e) {
-		    System.err.println(e);
-		    e.printStackTrace();
-		}
-		
+
 		try {
 			Files.deleteIfExists(destDir);
+		} catch (NoSuchFileException e) {
+			System.err.format("%s: no such" + " file or directory%n", destDir);
+			e.printStackTrace();
+		} catch (DirectoryNotEmptyException e) {
+			System.err.format("%s not empty%n", destDir);
+			e.printStackTrace();
+		} catch (IOException e) {
+			System.err.println(e);
+			e.printStackTrace();
 		}
-		catch (NoSuchFileException e) {
-		    System.err.format("%s: no such" + " file or directory%n", destDir);
-		    e.printStackTrace();
-		} 
-		catch (DirectoryNotEmptyException e) {
-		    System.err.format("%s not empty%n", destDir);
-		    e.printStackTrace();
-		} 
-		catch (IOException e) {
-		    System.err.println(e);
-		    e.printStackTrace();
-		}
-	
-		
+
 	}
-	
-	
+
 	/**
 	 * Test for method {@link org.eclipse.ice.commands.LocalMoveFileCommand()}
 	 */
 	@Test
 	public void testLocalMoveFileCommand() {
-	
+
 		System.out.println("Moving: " + source + " to destination: " + dest);
 		// Make the command
-		LocalMoveFileCommand command = 
-				new LocalMoveFileCommand(source, dest);		
+		LocalMoveFileCommand command = new LocalMoveFileCommand(source, dest);
 		command.execute();
-		
+
 		// Check if the path exists now
 		Path path = Paths.get(dest);
-		assert(Files.exists(path));
-				
+		assert (Files.exists(path));
+
 	}
 
 }

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalMoveFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalMoveFileCommandTest.java
@@ -12,11 +12,14 @@
 package org.eclipse.ice.tests.commands;
 
 import java.io.IOException;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.eclipse.ice.commands.LocalMoveFileCommand;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,12 +33,12 @@ public class LocalMoveFileCommandTest {
 	/**
 	 * A source file that is created for testing
 	 */
-	String source;
+	String source = null;
 	
 	/**
 	 * A destination path that is created for testing 
 	 */
-	String dest;
+	String dest = null;
 	
 	/**
 	 * This function sets up and creates a dummy test file for 
@@ -73,6 +76,70 @@ public class LocalMoveFileCommandTest {
 		// Turn the path into a string to give to the command
 		dest = destinationPath.toString();
 	}
+	
+	
+	
+	/**
+	 * Deletes the temporarily made files since they are not useful
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+		
+		// Need to get the filename individually
+		String delims = "[/]";
+		String[] tokens = source.split(delims);
+		String filename = tokens[tokens.length-1];
+		
+		// Make the destination path + the filename
+		String fullDestination = dest + "/" + filename;
+		
+
+		// Get the paths
+		Path destFile = Paths.get(fullDestination);
+		Path destDir = Paths.get(dest);
+		
+		
+		// Delete the files
+		// Only need to delete the moved file and destination directory,
+		// since the source file was created in the default system directory
+		// which can't be deleted and the moved file, by definition, doesn't
+		// exist in the original directory
+		try {
+			Files.deleteIfExists(destFile);
+		}
+		catch (NoSuchFileException e) {
+		    System.err.format("%s: no such" + " file or directory%n", destFile);
+		    e.printStackTrace();
+		} 
+		catch (DirectoryNotEmptyException e) {
+		    System.err.format("%s not empty%n", destFile);
+		    e.printStackTrace();
+		} 
+		catch (IOException e) {
+		    System.err.println(e);
+		    e.printStackTrace();
+		}
+		
+		try {
+			Files.deleteIfExists(destDir);
+		}
+		catch (NoSuchFileException e) {
+		    System.err.format("%s: no such" + " file or directory%n", destDir);
+		    e.printStackTrace();
+		} 
+		catch (DirectoryNotEmptyException e) {
+		    System.err.format("%s not empty%n", destDir);
+		    e.printStackTrace();
+		} 
+		catch (IOException e) {
+		    System.err.println(e);
+		    e.printStackTrace();
+		}
+	
+		
+	}
+	
 	
 	/**
 	 * Test for method {@link org.eclipse.ice.commands.LocalMoveFileCommand()}

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalMoveFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/LocalMoveFileCommandTest.java
@@ -150,8 +150,9 @@ public class LocalMoveFileCommandTest {
 		System.out.println("Moving: " + source + " to destination: " + dest);
 		// Make the command
 		LocalMoveFileCommand command = 
-				new LocalMoveFileCommand(source, dest);
-				
+				new LocalMoveFileCommand(source, dest);		
+		command.execute();
+		
 		// Check if the path exists now
 		Path path = Paths.get(dest);
 		assert(Files.exists(path));

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/MoveFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/MoveFileCommandTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 /**
  * Test for class {@link org.eclipse.ice.commands.MoveFileCommand}.
+ * 
  * @author Joe Osborn
  *
  */
@@ -58,7 +59,7 @@ public class MoveFileCommandTest {
 	public void test() {
 		fail("Not yet implemented");
 	}
-	
+
 	/**
 	 * Test for method {@link org.eclipse.ice.commands.MoveFileCommand()}
 	 */

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteCommandTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 /**
  * Test for class {@link org.eclipse.ice.commands.RemoteCommand}.
+ * 
  * @author Joe Osborn
  *
  */
@@ -53,12 +54,12 @@ public class RemoteCommandTest {
 	@After
 	public void tearDown() throws Exception {
 	}
-	
+
 	@Test
 	public void test() {
 		fail("Not yet implemented");
 	}
-	
+
 	/**
 	 * Test for method {@link org.eclipse.ice.commands.RemoteCommand()}
 	 */
@@ -67,14 +68,16 @@ public class RemoteCommandTest {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.ice.commands.RemoteCommand#SetConnection(String)}
+	 * Test method for
+	 * {@link org.eclipse.ice.commands.RemoteCommand#SetConnection(String)}
 	 */
 	public void testSetConnection() {
 		fail("Not yet implemented");
 	}
-	
+
 	/**
-	 * Test method for {@link org.eclipse.ice.commans.RemoteCommand#GetConnection(String)}
+	 * Test method for
+	 * {@link org.eclipse.ice.commans.RemoteCommand#GetConnection(String)}
 	 */
 	public void testGetConnection() {
 		fail("Not yet implemented");

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteCopyFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteCopyFileCommandTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 /**
  * Test for class {@link org.eclipse.ice.commands.RemoteCopyFileCommand}.
+ * 
  * @author Joe Osborn
  *
  */
@@ -58,7 +59,7 @@ public class RemoteCopyFileCommandTest {
 	public void test() {
 		fail("Not yet implemented");
 	}
-	
+
 	/**
 	 * Test for method {@link org.eclipse.ice.commands.RemoteCopyFileCommand()}
 	 */

--- a/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteMoveFileCommandTest.java
+++ b/org.eclipse.ice.commands/src/test/java/org/eclipse/ice/tests/commands/RemoteMoveFileCommandTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 /**
  * Test for class {@link org.eclipse.ice.commands.RemoteMoveFileCommand}.
+ * 
  * @author Joe Osborn
  *
  */
@@ -58,7 +59,7 @@ public class RemoteMoveFileCommandTest {
 	public void test() {
 		fail("Not yet implemented");
 	}
-	
+
 	/**
 	 * Test for method {@link org.eclipse.ice.commands.RemoteMoveFileCommand()}
 	 */


### PR DESCRIPTION
## Summary
This PR addresses the issues [392](https://github.com/eclipse/ice/issues/392), [394](https://github.com/eclipse/ice/issues/394), [398](https://github.com/eclipse/ice/issues/398), [400](https://github.com/eclipse/ice/issues/400), [401](https://github.com/eclipse/ice/issues/401), and [402](https://github.com/eclipse/ice/issues/402). Most of these are small changes, but a few details about more significant changes are described below. 

### Changes in FileHandler
The main issue resolved is that FileHandler now returns a Command which the user tells to execute, rather than the execution being performed in the constructor of a CopyFile or MoveFile Command.

FileHandlerTest also now creates and destroys temporary test files.

### Logger
A logger was also added to replace the System.out print statements. The logger prints to the console as defined by a very basic default log4j.properties file that was added to the resources directory. This directory is by default included in the classpath so the maven project picks it up and applies it at run time (e.g. in CommandFactoryTest).