### PR TITLE
Unit tests for DataElementProcessor

### DIFF
--- a/org.eclipse.ice.dev.annotations/pom.xml
+++ b/org.eclipse.ice.dev.annotations/pom.xml
@@ -88,6 +88,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.google.testing.compile</groupId>
+			<artifactId>compile-testing</artifactId>
+			<version>0.18</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.mongodb</groupId>
 			<artifactId>mongo-java-driver</artifactId>
 			<version>3.12.2</version>

--- a/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/DataElementProcessor.java
+++ b/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/DataElementProcessor.java
@@ -47,7 +47,7 @@ import com.google.auto.service.AutoService;
 	"org.eclipse.ice.dev.annotations.DataField.Default",
 	"org.eclipse.ice.dev.annotations.Persisted"
 })
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 @AutoService(Processor.class)
 public class DataElementProcessor extends AbstractProcessor {
 

--- a/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/DataElementSpec.java
+++ b/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/DataElementSpec.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 
@@ -73,7 +74,7 @@ public class DataElementSpec extends AnnotatedElement {
 	 */
 	public DataElementSpec(Element element, Elements elementUtils) throws InvalidDataElementSpec {
 		super(element, elementUtils);
-		if (!element.getKind().isClass()) {
+		if (element.getKind() != ElementKind.CLASS) {
 			throw new InvalidDataElementSpec(
 				"DataElementSpec must be class, found " + element.toString()
 			);

--- a/org.eclipse.ice.dev.annotations/src/main/resources/templates/DataElement.vm
+++ b/org.eclipse.ice.dev.annotations/src/main/resources/templates/DataElement.vm
@@ -134,6 +134,7 @@ public class ${class} implements ${interface}, Serializable {
 					// by debuggers.
 					#foreach($field in ${fields.Match})
 
+					// Matching ${field.Name}
 					boolean ${field.Name}Match =
 					#if(${field.Nullable})
 						this.${field.Name} == null ?
@@ -144,8 +145,6 @@ public class ${class} implements ${interface}, Serializable {
 					#else
 						this.${field.Name}.equals(other.${field.Name});
 					#end## if nullable
-					#else
-					// Not checking ${field.Name}
 					#end## foreach
 
 					retval =

--- a/org.eclipse.ice.dev.annotations/src/main/resources/templates/ElementInterface.vm
+++ b/org.eclipse.ice.dev.annotations/src/main/resources/templates/ElementInterface.vm
@@ -18,7 +18,7 @@ public interface $interface extends IDataElement<${interface}> {
 	 * Get ${field.Name}.
 	 * @return ${field.Name}
 	 */
-	public #fieldtype get${field.NameForMethod}();
+	public #fieldtype #getterprefix${field.NameForMethod}();
 	#end## if Getter
 	#if(${field.Setter})
 

--- a/org.eclipse.ice.dev.annotations/src/main/resources/templates/common.vm
+++ b/org.eclipse.ice.dev.annotations/src/main/resources/templates/common.vm
@@ -37,3 +37,4 @@ $shift$bodyContent.toString().replace("$tab", "").replace("$newline", "$newline$
 	 */
 	#end
 #end
+#macro(getterprefix)#if(${field.Type} == "boolean")is#{else}get#end#end

--- a/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/DataElementProcessorTest.java
+++ b/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/DataElementProcessorTest.java
@@ -1,5 +1,7 @@
 package org.eclipse.ice.tests.dev.annotations.processors;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
@@ -61,7 +63,8 @@ class DataElementProcessorTest {
 		MANY("Many.java"),
 		SINGLE_NON_PRIMITIVE("SingleNonPrimitive.java"),
 		MANY_NON_PRIMITIVE("ManyNonPrimitive.java"),
-		ACCESSIBILITY_PRESERVED("AccessibilityPreserved.java");
+		ACCESSIBILITY_PRESERVED("AccessibilityPreserved.java"),
+		DATAFIELD_ON_CLASS("DataFieldOnClass.java");
 
 		/**
 		 * Parent directory of inputs. Prepended to all paths.
@@ -133,10 +136,12 @@ class DataElementProcessorTest {
 			Constructor<?> constructor = c.getConstructor();
 			constructor.setAccessible(true);
 			p = (Processor) constructor.newInstance();
-		} catch (ClassNotFoundException | InstantiationException |
+		} catch (
+			ClassNotFoundException | InstantiationException |
 			IllegalAccessException | IllegalArgumentException |
 			InvocationTargetException | NoSuchMethodException |
-			SecurityException e) {
+			SecurityException e
+		) {
 			System.err.println("Failed to get Lombok AnnotationProcessor!");
 			e.printStackTrace();
 		}
@@ -314,9 +319,72 @@ class DataElementProcessorTest {
 		assertImplementationMatches(compilation, Patterns.ACCESSIBILITY_PRESERVED.get());
 	}
 
-	// TODO test that annotating something other than a field with @DataField fails
-	// TODO test that @DataField.Default generates as expected
-	// TODO test @DataFieldJson works
-	// TODO kitchen sink element
+	/**
+	 * Test that annotating a class with {@code @DataField} fails.
+	 *
+	 * This should be enough to also ensure that it will fail for other types as
+	 * well.
+	 */
+	@Test
+	void testDataFieldOnClassFails() {
+		Compilation compilation = compile(Inputs.DATAFIELD_ON_CLASS.get());
+		assertThat(compilation)
+			.hadErrorContaining("annotation type not applicable");
+	}
 
+	/**
+	 * Test DataField Getter option.
+	 */
+	@Test
+	void testDataFieldGetterOption() {
+		fail("Getter option not yet implemented");
+	}
+
+	/**
+	 * Test DataField Setter option.
+	 */
+	@Test
+	void testDataFieldSetterOption() {
+		fail("Setter option not yet implemented");
+	}
+
+	/**
+	 * Test DataField Match option.
+	 */
+	@Test
+	void testDataFieldMatchOption() {
+		fail("Match option not yet implemented");
+	}
+
+	/**
+	 * Test Persisted Annotation.
+	 */
+	@Test
+	void testPersisted() {
+		fail("Persisted not yet implemented");
+	}
+
+	/**
+	 * Test DataField Search option.
+	 */
+	@Test
+	void testDataFieldSearchOption() {
+		fail("Search option not yet implemented");
+	}
+
+	/**
+	 * Test DataField.Default generation.
+	 */
+	@Test
+	void testDataFieldDefault() {
+		fail("DataField.Default not yet implemented");
+	}
+
+	/**
+	 * Test DataFieldJson annotation.
+	 */
+	@Test
+	void testDataFieldJson() {
+		fail("DataFieldJson not yet implemented");
+	}
 }

--- a/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/DataElementProcessorTest.java
+++ b/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/DataElementProcessorTest.java
@@ -64,7 +64,13 @@ class DataElementProcessorTest {
 		SINGLE_NON_PRIMITIVE("SingleNonPrimitive.java"),
 		MANY_NON_PRIMITIVE("ManyNonPrimitive.java"),
 		ACCESSIBILITY_PRESERVED("AccessibilityPreserved.java"),
-		DATAFIELD_ON_CLASS("DataFieldOnClass.java");
+		DATAFIELD_ON_CLASS("DataFieldOnClass.java"),
+		DATAFIELD_ON_METHOD("DataFieldOnMethod.java"),
+		DATAFIELD_GETTER("Getter.java"),
+		DATAFIELD_SETTER("Setter.java"),
+		DATAFIELD_MATCH("Match.java"),
+		DEFAULT_NON_STRING("DefaultNonString.java"),
+		DEFAULT_STRING("DefaultString.java");
 
 		/**
 		 * Parent directory of inputs. Prepended to all paths.
@@ -101,7 +107,11 @@ class DataElementProcessorTest {
 		SINGLE_NON_PRIMITIVE_IMPL("SingleNonPrimitiveImplementation.java"),
 		MANY_NON_PRIMITIVE_INT("ManyNonPrimitive.java"),
 		MANY_NON_PRIMITIVE_IMPL("ManyNonPrimitiveImplementation.java"),
-		ACCESSIBILITY_PRESERVED("AccessibilityPreserved.java");
+		ACCESSIBILITY_PRESERVED("AccessibilityPreserved.java"),
+		DATAFIELD_GETTER_INT("Getter.java"),
+		DATAFIELD_SETTER_INT("Setter.java"),
+		DEFAULT_NON_STRING_IMPL("DefaultNonStringImplementation.java"),
+		DEFAULT_STRING_IMPL("DefaultStringImplementation.java");
 
 		/**
 		 * Parent directory of inputs. Prepended to all paths.
@@ -322,8 +332,8 @@ class DataElementProcessorTest {
 	/**
 	 * Test that annotating a class with {@code @DataField} fails.
 	 *
-	 * This should be enough to also ensure that it will fail for other types as
-	 * well.
+	 * This should be enough to also ensure that it will fail for other types (enum,
+	 * interface, etc.).
 	 */
 	@Test
 	void testDataFieldOnClassFails() {
@@ -333,11 +343,24 @@ class DataElementProcessorTest {
 	}
 
 	/**
+	 * Test that annotating a class method with {@code @DataField} fails.
+	 */
+	@Test
+	void testDataFieldOnMethodFails() {
+		Compilation compilation = compile(Inputs.DATAFIELD_ON_METHOD.get());
+		assertThat(compilation)
+			.hadErrorContaining("annotation type not applicable");
+	}
+
+	/**
 	 * Test DataField Getter option.
 	 */
 	@Test
 	void testDataFieldGetterOption() {
-		fail("Getter option not yet implemented");
+		Compilation compilation = compile(Inputs.DATAFIELD_GETTER.get());
+		assertThat(compilation)
+			.generatedSourceFile(INTERFACE)
+			.hasSourceEquivalentTo(Patterns.DATAFIELD_GETTER_INT.get());
 	}
 
 	/**
@@ -345,7 +368,10 @@ class DataElementProcessorTest {
 	 */
 	@Test
 	void testDataFieldSetterOption() {
-		fail("Setter option not yet implemented");
+		Compilation compilation = compile(Inputs.DATAFIELD_SETTER.get());
+		assertThat(compilation)
+			.generatedSourceFile(INTERFACE)
+			.hasSourceEquivalentTo(Patterns.DATAFIELD_SETTER_INT.get());
 	}
 
 	/**
@@ -353,38 +379,47 @@ class DataElementProcessorTest {
 	 */
 	@Test
 	void testDataFieldMatchOption() {
-		fail("Match option not yet implemented");
+		Compilation compilation = compile(Inputs.DATAFIELD_MATCH.get());
+		assertThat(compilation)
+			.generatedSourceFile(IMPLEMENTATION)
+			.contentsAsUtf8String()
+			.contains("Matching toBeMatched");
+		assertThat(compilation)
+			.generatedSourceFile(IMPLEMENTATION)
+			.contentsAsUtf8String()
+			.doesNotContain("Matching toNotBeMatched");
 	}
 
 	/**
-	 * Test Persisted Annotation.
+	 * Test DataField.Default generation for Non-String values.
 	 */
 	@Test
-	void testPersisted() {
-		fail("Persisted not yet implemented");
+	void testDataFieldDefaultNonString() {
+		Compilation compilation = compile(Inputs.DEFAULT_NON_STRING.get());
+		assertImplementationMatches(
+			compilation,
+			Patterns.DEFAULT_NON_STRING_IMPL.get()
+		);
 	}
 
 	/**
-	 * Test DataField Search option.
+	 * Test DataField.Default generation for String values.
 	 */
 	@Test
-	void testDataFieldSearchOption() {
-		fail("Search option not yet implemented");
+	void testDataFieldDefaultString() {
+		Compilation compilation = compile(Inputs.DEFAULT_STRING.get());
+		assertImplementationMatches(
+			compilation,
+			Patterns.DEFAULT_STRING_IMPL.get()
+		);
 	}
 
-	/**
-	 * Test DataField.Default generation.
-	 */
-	@Test
-	void testDataFieldDefault() {
-		fail("DataField.Default not yet implemented");
-	}
-
-	/**
-	 * Test DataFieldJson annotation.
-	 */
-	@Test
-	void testDataFieldJson() {
-		fail("DataFieldJson not yet implemented");
-	}
+	// TODO rework DataFieldJson? Merge into DataElement Annotation?
+//	/**
+//	 * Test DataFieldJson annotation.
+//	 */
+//	@Test
+//	void testDataFieldJson() {
+//		fail("DataFieldJson not yet implemented");
+//	}
 }

--- a/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/DataElementProcessorTest.java
+++ b/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/DataElementProcessorTest.java
@@ -1,0 +1,200 @@
+package org.eclipse.ice.tests.dev.annotations.processors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import static com.google.testing.compile.Compiler.*;
+import static com.google.testing.compile.CompilationSubject.*;
+
+import javax.annotation.processing.Processor;
+import javax.tools.JavaFileObject;
+
+import org.eclipse.ice.dev.annotations.processors.DataElementProcessor;
+import org.junit.jupiter.api.Test;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+
+import lombok.AllArgsConstructor;
+
+class DataElementProcessorTest {
+
+	private static final String INTERFACE = "Test";
+	private static final String IMPLEMENTATION = "TestImplementation";
+
+	@AllArgsConstructor
+	private static enum Inputs {
+		HELLO_WORLD("HelloWorld.java"),
+		NAME_MISSING("DataElementNameMissing.java"),
+		ON_ENUM("DataElementOnEnum.java"),
+		ON_INTERFACE("DataElementOnInterface.java"),
+		NO_DATAFIELDS("NoDataFields.java"),
+		SINGLE("Single.java"),
+		MANY("Many.java"),
+		SINGLE_NON_PRIMITIVE("SingleNonPrimitive.java"),
+		MANY_NON_PRIMITIVE("ManyNonPrimitive.java"),
+		ACCESSIBILITY_PRESERVED("AccessibilityPreserved.java");
+
+		private static final String PARENT = "input/";
+		private String path;
+		public JavaFileObject get() {
+			return JavaFileObjects.forResource(PARENT + this.path);
+		}
+	}
+
+	@AllArgsConstructor
+	private static enum Patterns {
+		DEFAULTS_INT("Defaults.java"),
+		DEFAULTS_IMPL("DefaultsImplementation.java"),
+		SINGLE_INT("Single.java"),
+		SINGLE_IMPL("SingleImplementation.java"),
+		MANY_INT("Many.java"),
+		MANY_IMPL("ManyImplementation.java"),
+		SINGLE_NON_PRIMITIVE_INT("SingleNonPrimitive.java"),
+		SINGLE_NON_PRIMITIVE_IMPL("SingleNonPrimitiveImplementation.java"),
+		MANY_NON_PRIMITIVE_INT("ManyNonPrimitive.java"),
+		MANY_NON_PRIMITIVE_IMPL("ManyNonPrimitiveImplementation.java"),
+		ACCESSIBILITY_PRESERVED("AccessibilityPreserved.java");
+
+		private static final String PARENT = "patterns/";
+		private String path;
+		public JavaFileObject get() {
+			return JavaFileObjects.forResource(PARENT + this.path);
+		}
+	}
+
+	/**
+	 * Retrieve an instance of Lombok's Annotation Processor.
+	 *
+	 * This is a nasty method that violates the accessibility of the Processor by
+	 * reflection but is necessary to correctly process and test the generated code.
+	 * @return lombok annotation processor
+	 */
+	private static Processor getLombokAnnotationProcessor() {
+		Processor p = null;
+		try {
+			Class<?> c = Class.forName("lombok.launch.AnnotationProcessorHider$AnnotationProcessor");
+			Constructor<?> constructor = c.getConstructor();
+			constructor.setAccessible(true);
+			p = (Processor) constructor.newInstance();
+		} catch (ClassNotFoundException | InstantiationException |
+			IllegalAccessException | IllegalArgumentException |
+			InvocationTargetException | NoSuchMethodException |
+			SecurityException e) {
+			System.err.println("Failed to get Lombok AnnotationProcessor!");
+			e.printStackTrace();
+		}
+		return p;
+	}
+
+	private static Compilation compile(JavaFileObject... sources) {
+		return javac()
+			.withProcessors(
+				getLombokAnnotationProcessor(),
+				new DataElementProcessor()
+			).compile(sources);
+	}
+
+	private static void assertInterfaceMatches(Compilation compilation, JavaFileObject inter) {
+		assertThat(compilation)
+			.generatedSourceFile(INTERFACE)
+			.containsElementsIn(inter);
+	}
+
+	private static void assertImplementationMatches(Compilation compilation, JavaFileObject impl) {
+		assertThat(compilation)
+			.generatedSourceFile(IMPLEMENTATION)
+			.containsElementsIn(impl);
+	}
+
+	private static void assertDefaultsPresent(Compilation compilation) {
+		assertInterfaceMatches(compilation, Patterns.DEFAULTS_INT.get());
+		assertImplementationMatches(compilation, Patterns.DEFAULTS_IMPL.get());
+	}
+
+	@Test
+	void testNoAnnotationsToProcessSucceeds() {
+		Compilation compilation = compile(Inputs.HELLO_WORLD.get());
+		assertThat(compilation).succeeded();
+	}
+
+	@Test
+	void testMissingNameFails() {
+		Compilation compilation = compile(Inputs.NAME_MISSING.get());
+		assertThat(compilation)
+			.hadErrorContaining(
+				"missing a default value for the element 'name'"
+			);
+	}
+
+	@Test
+	void testAnnotateInterfaceFails() {
+		Compilation compilation = compile(Inputs.ON_INTERFACE.get());
+		assertThat(compilation)
+			.hadErrorContaining("DataElementSpec must be class");
+	}
+
+	@Test
+	void testAnnotateEnumFails() {
+		Compilation compilation = compile(Inputs.ON_ENUM.get());
+		assertThat(compilation)
+			.hadErrorContaining("DataElementSpec must be class");
+	}
+
+	@Test
+	void testNoDataFieldsSucceeds() {
+		Compilation compilation = compile(Inputs.NO_DATAFIELDS.get());
+		assertDefaultsPresent(compilation);
+	}
+
+	@Test
+	void testWithSingleDataFieldSucceeds() {
+		Compilation compilation = compile(Inputs.SINGLE.get());
+		assertDefaultsPresent(compilation);
+		assertInterfaceMatches(compilation, Patterns.SINGLE_INT.get());
+		assertImplementationMatches(compilation, Patterns.SINGLE_IMPL.get());
+	}
+
+	@Test
+	void testWithManyDataFieldsSucceeds() {
+		Compilation compilation = compile(Inputs.MANY.get());
+		assertDefaultsPresent(compilation);
+		assertInterfaceMatches(compilation, Patterns.MANY_INT.get());
+		assertImplementationMatches(compilation, Patterns.MANY_IMPL.get());
+	}
+
+	@Test
+	void testSingleNonPrimitiveDataFieldSucceeds() {
+		Compilation compilation = compile(Inputs.SINGLE_NON_PRIMITIVE.get());
+		assertDefaultsPresent(compilation);
+		assertInterfaceMatches(compilation, Patterns.SINGLE_NON_PRIMITIVE_INT.get());
+		assertImplementationMatches(compilation, Patterns.SINGLE_NON_PRIMITIVE_IMPL.get());
+	}
+
+	@Test
+	void testManyNonPrimitiveDataFieldSucceeds() {
+		Compilation compilation = compile(Inputs.MANY_NON_PRIMITIVE.get());
+		assertDefaultsPresent(compilation);
+		assertInterfaceMatches(compilation, Patterns.MANY_NON_PRIMITIVE_INT.get());
+		assertImplementationMatches(compilation, Patterns.MANY_NON_PRIMITIVE_IMPL.get());
+	}
+
+	@Test
+	void testDocStringsPreserved() {
+		Compilation compilation = compile(Inputs.SINGLE.get());
+		assertThat(compilation).generatedSourceFile(IMPLEMENTATION)
+			.contentsAsUtf8String()
+			.contains("* A UNIQUE STRING IN THE DOC STRING.");
+		assertThat(compilation).generatedSourceFile(IMPLEMENTATION)
+			.contentsAsUtf8String()
+			.contains("* AND ANOTHER ON A NEW LINE.");
+	}
+
+	@Test
+	void testAccessibilityPreserved() {
+		Compilation compilation = compile(Inputs.ACCESSIBILITY_PRESERVED.get());
+		assertImplementationMatches(compilation, Patterns.ACCESSIBILITY_PRESERVED.get());
+	}
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/AccessibilityPreserved.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/AccessibilityPreserved.java
@@ -1,0 +1,10 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataElement(name = "Test")
+public class AccessibilityPreserved {
+	@DataField public int shouldBePublic;
+	@DataField protected int shouldBeProtected;
+	@DataField private int shouldBePrivate;
+	@DataField int shouldBePackage;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/DataElementNameMissing.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/DataElementNameMissing.java
@@ -1,0 +1,8 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+
+@DataElement
+public class DataElementNameMissing {
+	public static void main(String[] args) {
+		System.out.println("Hello, world!");
+	}
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/DataElementOnEnum.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/DataElementOnEnum.java
@@ -1,0 +1,6 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+
+@DataElement(name = "ShouldHaveBeenAClass")
+public enum DataElementOnEnum {
+	HELLO, WORLD;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/DataElementOnInterface.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/DataElementOnInterface.java
@@ -1,0 +1,6 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+
+@DataElement(name = "ShouldHaveBeenAClass")
+public interface DataElementOnInterface {
+	public static void main(String[] args);
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/DataFieldOnClass.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/DataFieldOnClass.java
@@ -1,0 +1,4 @@
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataField
+public class DataFieldOnClass {}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/DataFieldOnMethod.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/DataFieldOnMethod.java
@@ -1,0 +1,11 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataElement(name = "Broken")
+public class DataFieldOnMethod {
+	@DataField private int test;
+	@DataField
+	public int testMethod() {
+		return 0;
+	}
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/DefaultNonString.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/DefaultNonString.java
@@ -1,0 +1,8 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataElement(name = "Test")
+public class DefaultNonString {
+	@DataField.Default("42")
+	@DataField public int testInt;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/DefaultString.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/DefaultString.java
@@ -1,0 +1,8 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataElement(name = "Test")
+public class DefaultString {
+	@DataField.Default(value = "A String Value", isString = true)
+	@DataField public String test;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/Getter.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/Getter.java
@@ -1,0 +1,8 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataElement(name = "Test")
+public class Getter {
+	@DataField(getter = false)
+	public int test;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/HelloWorld.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/HelloWorld.java
@@ -1,0 +1,5 @@
+public class HelloWorld {
+	public static void main(String[] args) {
+		System.out.println("Hello, world!");
+	}
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/Many.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/Many.java
@@ -1,0 +1,14 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataElement(name = "Test")
+public class Many {
+	@DataField public byte testByte;
+	@DataField public short testShort;
+	@DataField public int testInt;
+	@DataField public long testLong;
+	@DataField public float testFloat;
+	@DataField public double testDouble;
+	@DataField public boolean testBoolean;
+	@DataField public char testChar;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/ManyNonPrimitive.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/ManyNonPrimitive.java
@@ -1,0 +1,9 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataElement(name = "Test")
+public class ManyNonPrimitive {
+	@DataField public java.util.UUID testUuid;
+	@DataField public java.lang.String testString;
+	@DataField public java.util.Date testDate;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/Match.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/Match.java
@@ -1,0 +1,9 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataElement(name = "Test")
+public class Match {
+	@DataField public int toBeMatched;
+	@DataField(match = false)
+	public int toNotBeMatched;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/NoDataFields.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/NoDataFields.java
@@ -1,0 +1,4 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+
+@DataElement(name = "Test")
+public class NoDataFields { }

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/Setter.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/Setter.java
@@ -1,0 +1,8 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataElement(name = "Test")
+public class Setter {
+	@DataField(setter = false)
+	public int test;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/Single.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/Single.java
@@ -1,0 +1,12 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataElement(name = "Test")
+public class Single {
+	/**
+	 * A UNIQUE STRING IN THE DOC STRING.
+	 *
+	 * AND ANOTHER ON A NEW LINE.
+	 */
+	@DataField public int testInt;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/input/SingleNonPrimitive.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/input/SingleNonPrimitive.java
@@ -1,0 +1,7 @@
+import org.eclipse.ice.dev.annotations.DataElement;
+import org.eclipse.ice.dev.annotations.DataField;
+
+@DataElement(name = "Test")
+public class SingleNonPrimitive {
+	@DataField public java.util.UUID testUuid;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/AccessibilityPreserved.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/AccessibilityPreserved.java
@@ -1,0 +1,8 @@
+@Data
+@NoArgsConstructor
+public class TestImplementation implements Test, Serializable {
+	public int shouldBePublic;
+	protected int shouldBeProtected;
+	private int shouldBePrivate;
+	int shouldBePackage;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultNonStringImplementation.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultNonStringImplementation.java
@@ -1,0 +1,5 @@
+@Data
+@NoArgsConstructor
+public class TestImplementation implements Test, Serializable {
+	public int testInt = 42;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultStringImplementation.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultStringImplementation.java
@@ -1,0 +1,5 @@
+@Data
+@NoArgsConstructor
+public class TestImplementation implements Test, Serializable {
+	@NonNull public java.lang.String test = "A String Value";
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/Defaults.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/Defaults.java
@@ -1,0 +1,2 @@
+import org.eclipse.ice.dev.annotations.IDataElement;
+public interface Test extends IDataElement<Test> {}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultsImplementation.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultsImplementation.java
@@ -1,0 +1,16 @@
+@Data
+@NoArgsConstructor
+public class TestImplementation implements Test, Serializable {
+	@NonNull
+	@Getter(AccessLevel.NONE)
+	@Setter(AccessLevel.NONE)
+	protected java.util.UUID privateId = java.util.UUID.randomUUID();
+	protected long id = 0L;
+	@NonNull protected java.lang.String name = "name";
+	@NonNull protected java.lang.String description = "description";
+	@NonNull protected java.lang.String comment = "no comment";
+	@NonNull protected java.lang.String context = "default";
+	protected boolean required = false;
+	protected boolean secret = false;
+	protected org.eclipse.ice.dev.annotations.JavascriptValidator<Test> validator;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/Getter.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/Getter.java
@@ -1,0 +1,4 @@
+import org.eclipse.ice.dev.annotations.IDataElement;
+public interface Test extends IDataElement<Test> {
+	public void setTest(int test);
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/Many.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/Many.java
@@ -1,0 +1,19 @@
+import org.eclipse.ice.dev.annotations.IDataElement;
+public interface Test extends IDataElement<Test> {
+	public byte getTestByte();
+	public void setTestByte(byte testByte);
+	public short getTestShort();
+	public void setTestShort(short testShort);
+	public int getTestInt();
+	public void setTestInt(int testInt);
+	public long getTestLong();
+	public void setTestLong(long testLong);
+	public float getTestFloat();
+	public void setTestFloat(float testFloat);
+	public double getTestDouble();
+	public void setTestDouble(double testDouble);
+	public boolean isTestBoolean();
+	public void setTestBoolean(boolean testBoolean);
+	public char getTestChar();
+	public void setTestChar(char testChar);
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/ManyImplementation.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/ManyImplementation.java
@@ -1,0 +1,12 @@
+@Data
+@NoArgsConstructor
+public class TestImplementation implements Test, Serializable {
+	public byte testByte;
+	public short testShort;
+	public int testInt;
+	public long testLong;
+	public float testFloat;
+	public double testDouble;
+	public boolean testBoolean;
+	public char testChar;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/ManyNonPrimitive.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/ManyNonPrimitive.java
@@ -1,0 +1,9 @@
+import org.eclipse.ice.dev.annotations.IDataElement;
+public interface Test extends IDataElement<Test> {
+	public java.util.UUID getTestUuid();
+	public void setTestUuid(java.util.UUID testUuid);
+	public java.lang.String getTestString();
+	public void setTestString(java.lang.String testString);
+	public java.util.Date getTestDate();
+	public void setTestDate(java.util.Date testDate);
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/ManyNonPrimitiveImplementation.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/ManyNonPrimitiveImplementation.java
@@ -1,0 +1,7 @@
+@Data
+@NoArgsConstructor
+public class TestImplementation implements Test, Serializable {
+	@NonNull public java.util.UUID testUuid;
+	@NonNull public java.lang.String testString;
+	@NonNull public java.util.Date testDate;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/Setter.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/Setter.java
@@ -1,0 +1,4 @@
+import org.eclipse.ice.dev.annotations.IDataElement;
+public interface Test extends IDataElement<Test> {
+	public int getTest();
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/Single.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/Single.java
@@ -1,0 +1,5 @@
+import org.eclipse.ice.dev.annotations.IDataElement;
+public interface Test extends IDataElement<Test> {
+	public int getTestInt();
+	public void setTestInt(int testInt);
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/SingleImplementation.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/SingleImplementation.java
@@ -1,0 +1,5 @@
+@Data
+@NoArgsConstructor
+public class TestImplementation implements Test, Serializable {
+	public int testInt;
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/SingleNonPrimitive.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/SingleNonPrimitive.java
@@ -1,0 +1,5 @@
+import org.eclipse.ice.dev.annotations.IDataElement;
+public interface Test extends IDataElement<Test> {
+	public java.util.UUID getTestUuid();
+	public void setTestUuid(java.util.UUID testUuid);
+}

--- a/org.eclipse.ice.dev.annotations/src/test/resources/patterns/SingleNonPrimitiveImplementation.java
+++ b/org.eclipse.ice.dev.annotations/src/test/resources/patterns/SingleNonPrimitiveImplementation.java
@@ -1,0 +1,5 @@
+@Data
+@NoArgsConstructor
+public class TestImplementation implements Test, Serializable {
+	@NonNull public java.util.UUID testUuid;
+}


### PR DESCRIPTION
This PR adds unit tests for the `DataElementProcessor` using the compile-testing library.

The compile-testing library works by invoking the Java compiler through `javax.tools`. It creates an in-memory file manager so generated and compiled files aren't written to disk. The facilities it provides to then make assertions about the generated files are done through parsing the generated files and comparing the ASTs. As a result, we can test that annotations cause failures when we expect it to and that it generates files matching (with a high level of granularity) what we would expect it to generate **BUT**, as it does not compile the final generated classes, we cannot test the logic of generated classes in this manner.

Most of the tests use the "golden file" test strategy with the minor modification that the golden files are actually patterns. ASTs are parsed from the golden files/patterns and compared with the ASTs of the files generated from the input. In other words, the pattern AST must be a subgraph of the generated AST. A nuance of this strategy is that if methods are included in the pattern, the entire body of the method in the pattern must match exactly (AST-wise) the entire body of the method in the generated AST. Knowing that this would result in potentially brittle test cases, the patterns do not verify presence of the methods directly in the generated Implementation AST. They are, however, verified in the generated Interface and any methods missing in the implementation that are present in the interface are caught during testing. So by verifying both the methods in the interface and the fields in the implementation, the presence of all fields and methods on the generated implementation is verified.