### PR TITLE
Support directly (de)serializing DataElements with Jackson

### DIFF
--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations.proxytest/.classpath
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations.proxytest/.classpath
@@ -24,5 +24,16 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="/org.eclipse.ice.dev.annotations"/>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations.proxytest/src/test/java/org/eclipse/ice/dev/annotations/proxytest/GeneratedDataElementTest.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations.proxytest/src/test/java/org/eclipse/ice/dev/annotations/proxytest/GeneratedDataElementTest.java
@@ -171,7 +171,7 @@ class GeneratedDataElementTest {
 
 		// Because of the private id changing and being unique, this cannot be checked
 		// against a reference but can only be checked by inversion.
-		String output = element.toJSON();
+		String output = element.toJson();
 
 		// Change some values then read back in the original to make sure fromString()
 		// correctly overwrites them.
@@ -179,8 +179,8 @@ class GeneratedDataElementTest {
 		System.out.println(output);
 		GeneratedDataElement element2 = getStringElement("Emancipator");
 		element2.setValidator(new JavascriptValidator<GeneratedDataElement>());
-		element2.fromJSON(output);
-		element.fromJSON(output);
+		element2.fromJson(output);
+		element.fromJson(output);
 		assertEquals(element,element2);
 
 		return;
@@ -202,7 +202,7 @@ class GeneratedDataElementTest {
 
 		// Because of the private id changing and being unique, this cannot be checked
 		// against a reference but can only be checked by inversion.
-		String output = element.toJSON();
+		String output = element.toJson();
 
 		// Change some values then read back in the original to make sure fromString()
 		// correctly overwrites them.
@@ -211,7 +211,7 @@ class GeneratedDataElementTest {
 		pojo2.setDoubleValue(1.072);
 		element2.setValidator(new JavascriptValidator<GeneratedDataElementPOJO>());
 		element2.setTestPOJO(pojo2);
-		element2.fromJSON(output);
+		element2.fromJson(output);
 
 		assertEquals(element,element2);
 

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/IDataElement.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/IDataElement.java
@@ -158,6 +158,12 @@ public interface IDataElement<T> {
 	public Object clone();
 
 	/**
+	 * Copy the passed Element into this Element.
+	 * @param element the element to copy.
+	 */
+	public void copy(T element);
+
+	/**
 	 * This function checks deep equality of DataElements to see if all members are
 	 * equal ("match") with the exception of fields with match set to false (such
 	 * as an automatically generated UUID). This is important for checking if two

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/IDataElement.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/IDataElement.java
@@ -1,6 +1,5 @@
 package org.eclipse.ice.dev.annotations;
 
-import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -190,18 +189,6 @@ public interface IDataElement<T> {
 	 * @return the deserialized DataElement
 	 */
 	public T fromJson(final String jsonDataElement);
-
-	/**
-	 * Load from a String-Object Map, skipping the String parsing step. Structures
-	 * such as {@link org.bson.Document} implement {@code Map<String, Object>} and
-	 * therefore do not need to be processed from raw String form.
-	 *
-	 * @param <S> Object extending {@code Map<String, Object>}
-	 * @param jsonDataElement the contents of this data element as a
-	 *        {@code Map<String, Object>}
-	 * @return the deserialized DataElement
-	 */
-	public <S extends Map<String, Object>> T fromJSON(final S jsonDataElement);
 
 	/**
 	 * This operation returns the validator that has been configured for this

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/IDataElement.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/IDataElement.java
@@ -174,7 +174,7 @@ public interface IDataElement<T> {
 	 *
 	 * @return a JSON string describing the element
 	 */
-	public String toJSON();
+	public String toJson();
 
 	/**
 	 * This operation deserializes a valid JSON string and tries to load it into the
@@ -183,7 +183,7 @@ public interface IDataElement<T> {
 	 * @param jsonDataElement the contents of this data element as JSON
 	 * @return the deserialized DataElement
 	 */
-	public T fromJSON(final String jsonDataElement);
+	public T fromJson(final String jsonDataElement);
 
 	/**
 	 * Load from a String-Object Map, skipping the String parsing step. Structures

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/Field.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/Field.java
@@ -126,7 +126,7 @@ public class Field {
 	}
 
 	/**
-	 * Return this Fields name ready for use in a method.
+	 * Return this Fields name ready for use in a method name.
 	 * @return capitalized name
 	 */
 	@JsonIgnore
@@ -136,6 +136,10 @@ public class Field {
 
 	/**
 	 * Return the appropriate getter method name for this field.
+	 *
+	 * Due to the use of the Lombok {@code @Data} annotatation on DataElements, by
+	 * Lombok convention, Getters for fields of type {@code boolean} use "is"
+	 * instead of "get".
 	 * @return getter method name
 	 */
 	@JsonIgnore
@@ -151,6 +155,9 @@ public class Field {
 
 	/**
 	 * Return whether this field has a getter, directly or via one of its aliases.
+	 *
+	 * This method is separate from {@code getAnyGetter()} despite being very
+	 * similar for ease of use in velocity templates.
 	 * @return true if getter present, false otherwise
 	 */
 	@JsonIgnore
@@ -159,8 +166,9 @@ public class Field {
 	}
 
 	/**
-	 * Return the name of any valid getter for this field.
-	 * @return getter name, null if none
+	 * Return the name of any valid getter for this field, either a direct getter
+	 * for the field or one of its aliases.
+	 * @return getter name, null if none present
 	 */
 	@JsonIgnore
 	public String getAnyGetter() {
@@ -229,8 +237,8 @@ public class Field {
 		}
 
 		/**
-		 * Take a raw string value and pass through without manipulating for use as
-		 * type.
+		 * Set type to string. Attempts to determine the type to mark whether it
+		 * is primitive or not.
 		 * @param type String representation of type of this Field
 		 * @return this
 		 */

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/Field.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/Field.java
@@ -135,6 +135,50 @@ public class Field {
 	}
 
 	/**
+	 * Return the appropriate getter method name for this field.
+	 * @return getter method name
+	 */
+	@JsonIgnore
+	public String getGetterName() {
+		String prefix = null;
+		if (type != null && type.equals("boolean")) {
+			prefix = "is";
+		} else {
+			prefix = "get";
+		}
+		return prefix + getNameForMethod();
+	}
+
+	/**
+	 * Return whether this field has a getter, directly or via one of its aliases.
+	 * @return true if getter present, false otherwise
+	 */
+	@JsonIgnore
+	public boolean hasGetter() {
+		return getAnyGetter() != null;
+	}
+
+	/**
+	 * Return the name of any valid getter for this field.
+	 * @return getter name, null if none
+	 */
+	@JsonIgnore
+	public String getAnyGetter() {
+		String retval = null;
+		if (getter) {
+			retval = getGetterName();
+		} else {
+			for (Field alias : aliases) {
+				if (alias.isGetter()) {
+					retval = alias.getGetterName();
+					break;
+				}
+			}
+		}
+		return retval;
+	}
+
+	/**
 	 * Return if this field has a final modifier and is therefore a constant value.
 	 * @return field is constant
 	 */

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/DataElement.vm
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/DataElement.vm
@@ -168,7 +168,8 @@ public class ${class} implements ${interface}, Serializable {
 	 *
 	 * @return a JSON string describing the element
 	 */
-	public String toJSON() {
+	@Override
+	public String toJson() {
 		String value = null;
 		// Convert to json using Jackson
 		ObjectMapper mapper = new ObjectMapper();
@@ -214,8 +215,8 @@ public class ${class} implements ${interface}, Serializable {
 	 *
 	 * @param jsonDataElement the contents of this data element as JSON
 	 */
-	public $interface fromJSON(final String jsonDataElement) {
-
+	@Override
+	public $interface fromJson(final String jsonDataElement) {
 		// Load the data from the string with Jackson.
 		ObjectMapper mapper = new ObjectMapper();
 		try {

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/DataElement.vm
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/DataElement.vm
@@ -70,7 +70,7 @@ public class ${class} implements ${interface}, Serializable {
 	/**
 	 * Set ${field.Name} by alias ${alias.Name}.
 	 */
-	public void set${alias.NameForMethod}(#nonnull #fieldtype ${field.Name}) {
+	public void set${alias.NameForMethod}(#nonnull("", " ")#fieldtype ${field.Name}) {
 		this.${field.Name} = ${field.Name};
 	}
 			#end
@@ -78,20 +78,30 @@ public class ${class} implements ${interface}, Serializable {
 	#end
 
 	/**
+	 * All args constructor for $class.
+	 *
+	 * Used in JSON Deserialization.
+	#foreach($field in $fields)
+	 * @param ${field.Name} {@code #fieldtype} for field ${field.Name}
+	#end
+	 */
+	@JsonCreator
+	public $class(
+	#foreach($field in $fields)
+		@JsonProperty("${field.Name}") #nonnull("", " ")#fieldtype ${field.Name}#if($foreach.hasNext),#end
+	#end
+	) {
+		#foreach($field in $fields)
+		this.${field.Name} = ${field.Name};
+		#end
+	}
+
+	/**
 	 * Copy constructor for $class.
 	 * @param other Instance of $class to copy
-	 * @throws Exception if other is null or not of type $class or other errors.
 	 */
-	public $class($class other) throws Exception {
-		if (other == null) {
-			throw (new Exception("$class to copy cannot be null."));
-		}
-		if (!(other instanceof $class)) {
-			throw (new Exception("$class can copy only from other instances of $class."));
-		}
-		#foreach($field in $fields)
-		this.${field.Name} = other.${field.Name};
-		#end
+	public $class($interface other) {
+		copy(other);
 	}
 
 	/**
@@ -111,6 +121,19 @@ public class ${class} implements ${interface}, Serializable {
 	}
 
 	/**
+	 * Copy the contents of another element into this element.
+	 * @param element the element to copy
+	 */
+	@Override
+	public void copy(@NonNull $interface element) {
+		#foreach($field in $fields)
+			#if($field.hasGetter())
+		this.${field.Name} = element.${field.AnyGetter}();
+			#end
+		#end
+	}
+
+	/**
 	 * This function checks deep equality of DataElements to see if all members are
 	 * equal ("match") with the exception of fields with match set to false (such
 	 * as an automatically generated UUID). This is important for checking if two
@@ -120,6 +143,7 @@ public class ${class} implements ${interface}, Serializable {
 	 * @return true if all members of the element except excluded fields match
 	 *         this element.
 	 */
+	@Override
 	public boolean matches(Object o) {
 		boolean retval = false;
 
@@ -150,8 +174,8 @@ public class ${class} implements ${interface}, Serializable {
 					retval =
 					#@settab(6)
 						#foreach($field in ${fields.Match})#@nonewline
-						${field.Name}Match#if($foreach.hasNext) &&#if($foreach.count % 3 == 0)$newline#else #end#else;$newline#end
-						#end#end
+						${field.Name}Match#if($foreach.hasNext) &&#if($foreach.count % 3 == 0)$newline#else #end#end
+						#end#end;
 					#end
 				}
 			} else {

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/DataElement.vm
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/DataElement.vm
@@ -4,17 +4,15 @@ package $package;
 #end
 
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.Map;
-import java.util.HashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.AccessLevel;
@@ -30,6 +28,12 @@ import lombok.Setter;
  */
 @Data
 @NoArgsConstructor
+@JsonAutoDetect(
+	fieldVisibility = Visibility.ANY,
+	getterVisibility = Visibility.NONE,
+	isGetterVisibility = Visibility.NONE,
+	setterVisibility = Visibility.NONE
+)
 public class ${class} implements ${interface}, Serializable {
 
 	/**
@@ -197,11 +201,6 @@ public class ${class} implements ${interface}, Serializable {
 		String value = null;
 		// Convert to json using Jackson
 		ObjectMapper mapper = new ObjectMapper();
-		// Set visibility so that only methods are serialized. This removes duplication
-		// otherwise produced due to the convenience methods.
-		mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
-		mapper.setVisibility(PropertyAccessor.GETTER, Visibility.NONE);
-		mapper.setVisibility(PropertyAccessor.IS_GETTER, Visibility.NONE);
 		try {
 			value = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
 		} catch (JsonProcessingException e) {
@@ -209,28 +208,6 @@ public class ${class} implements ${interface}, Serializable {
 		}
 
 		return value;
-	}
-
-	/**
-	 * Load DataElement from JsonNode.
-	 * @param rootNode DataElement root as JsonNode
-	 * @param mapper ObjectMapper to convert values
-	 */
-	private void fromJsonNode(final JsonNode rootNode, final ObjectMapper mapper) throws JsonProcessingException {
-		#foreach($field in $fields)
-		// ${field.Name}
-		JsonNode ${field.Name}Node = rootNode.get("${field.Name}");
-		#if(${field.Nullable})
-		if (rootNode.hasNonNull("${field.Name}")) {
-			${field.Name} = mapper.treeToValue(${field.Name}Node, ${field.Name}.getClass());
-		} else {
-			${field.Name} = null;
-		}
-		#else
-		${field.Name} = mapper.treeToValue(${field.Name}Node, ${field.Type}.class);
-		#end
-
-		#end
 	}
 
 	/**
@@ -243,30 +220,9 @@ public class ${class} implements ${interface}, Serializable {
 	public $interface fromJson(final String jsonDataElement) {
 		// Load the data from the string with Jackson.
 		ObjectMapper mapper = new ObjectMapper();
+
 		try {
-			JsonNode rootNode = mapper.readTree(jsonDataElement);
-			fromJsonNode(rootNode, mapper);
-		} catch (JsonProcessingException e) {
-			logger.error("Unable to read DataElement from string!", e);
-		}
-
-		return this;
-	}
-
-	/**
-	 * Load from a String-Object Map, skipping the String parsing step. Structures
-	 * such as <code>org.bson.Document</code> implement Map<String, Object> and
-	 * therefore do not need to be processed from raw String form.
-	 *
-	 * @param jsonDataElement the contents of this data element as a Map<String, Object>
-	 */
-	public <T extends Map<String, Object>> $interface fromJSON(final T jsonDataElement) {
-
-		// Load the data from the string with Jackson.
-		ObjectMapper mapper = new ObjectMapper();
-		try {
-			JsonNode rootNode = mapper.valueToTree(jsonDataElement);
-			fromJsonNode(rootNode, mapper);
+			copy(mapper.readValue(jsonDataElement, ${class}.class));
 		} catch (JsonProcessingException e) {
 			logger.error("Unable to read DataElement from string!", e);
 		}

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/ElementInterface.vm
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/ElementInterface.vm
@@ -18,7 +18,7 @@ public interface $interface extends IDataElement<${interface}> {
 	 * Get ${field.Name}.
 	 * @return ${field.Name}
 	 */
-	public #fieldtype #getterprefix${field.NameForMethod}();
+	public #fieldtype ${field.GetterName}();
 	#end## if Getter
 	#if(${field.Setter})
 

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/PersistenceHandler.vm
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/PersistenceHandler.vm
@@ -52,7 +52,7 @@ public class $class implements $interface<$elementInterface> {
 	 */
 	@Override
 	public void save($elementInterface element) throws Exception {
-		this.collection.insertOne(Document.parse(element.toJSON()));
+		this.collection.insertOne(Document.parse(element.toJson()));
 	}
 
 	/**
@@ -64,7 +64,7 @@ public class $class implements $interface<$elementInterface> {
 	@Override
 	public Iterable<$elementInterface> findAll() throws Exception {
 		return this.collection.find()
-			.map(doc -> new ${implementation}().fromJSON(doc));
+			.map(doc -> new ${implementation}().fromJson(doc));
 	}
 
 	/**
@@ -99,7 +99,7 @@ public class $class implements $interface<$elementInterface> {
 			return null;
 		}
 
-		return new ${implementation}().fromJSON(doc);
+		return new ${implementation}().fromJson(doc);
 	}
 	#else
 
@@ -113,7 +113,7 @@ public class $class implements $interface<$elementInterface> {
 	#end
 	public Iterable<$elementInterface> findBy${var.NameForMethod}(${var.Type} ${var.Name}) throws Exception {
 		return this.collection.find(PersistenceFilters.eq("${var.Name}", ${var.Name}))
-			.map(doc -> new ${implementation}().fromJSON(doc));
+			.map(doc -> new ${implementation}().fromJson(doc));
 	}
 	#end## if unique
 	#end## if getter and search

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/PersistenceHandler.vm
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/PersistenceHandler.vm
@@ -64,7 +64,7 @@ public class $class implements $interface<$elementInterface> {
 	@Override
 	public Iterable<$elementInterface> findAll() throws Exception {
 		return this.collection.find()
-			.map(doc -> new ${implementation}().fromJson(doc));
+			.map(doc -> mapper.readValue(doc, ${implementation}.class);
 	}
 
 	/**
@@ -99,7 +99,7 @@ public class $class implements $interface<$elementInterface> {
 			return null;
 		}
 
-		return new ${implementation}().fromJson(doc);
+		return mapper.readValue(doc, ${implementation}.class);
 	}
 	#else
 
@@ -113,7 +113,7 @@ public class $class implements $interface<$elementInterface> {
 	#end
 	public Iterable<$elementInterface> findBy${var.NameForMethod}(${var.Type} ${var.Name}) throws Exception {
 		return this.collection.find(PersistenceFilters.eq("${var.Name}", ${var.Name}))
-			.map(doc -> new ${implementation}().fromJson(doc));
+			.map(doc -> mapper.readValue(doc, ${implementation}.class));
 	}
 	#end## if unique
 	#end## if getter and search

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/common.vm
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/common.vm
@@ -1,40 +1,69 @@
+##
 ## Macros and values useful across all templates and other readability helpers.
 ##
-## Whitespace helpers
-## ------------------
-##! Prepend a directive with this value if you don't want the directive to
-##! Gobble whitespace
-#set($blank = "")
-##! Literal newline
-#set($newline = "
+## Help make this file more readable.
+#macro(definitions)
+	#evaluate($bodyContent.toString().replaceAll("\n\p{Space}*\n", "").replaceAll("\p{Space}*##.*", ""))
+#end
+#@definitions
+
+	## Whitespace helpers ##
+
+	## Prepend a directive with this value if you don't want the directive to
+	## Gobble whitespace
+	#set($blank = "")
+
+	## Literal newline
+	#set($newline = "
 ")
-##! Literal tab
-#set($tab = "	")
-##! Gobbles whitespace
-#macro(noop)#end
-##! Use as a block macro to set the tab index of all lines in body.
-#macro(settab $num)
-#set($shift = "#foreach($i in [1..$num])$tab#end")
-$shift$bodyContent.toString().replace("$tab", "").replace("$newline", "$newline$shift")
-#end
-##! Use as a block macro to remove the first newline in the body.
-##! Useful when having foreach and output on the same line is unreadable but
-##! output is intended to be all on one line.
-#macro(nonewline)$bodyContent.toString().replaceFirst("\n", "")#end
-##
-## Field helpers
-#macro(fieldtype)#evaluate(${field.Type})#end
-#macro(annotations $annotations)#foreach($annotation in $annotations)$annotation #end#end
-#macro(modifiers $modifiers)#foreach($modifier in $modifiers)$modifier #end#end
-#macro(fielddecl)
-	$blank#annotations(${field.Annotations})#modifiers(${field.Modifiers})#fieldtype() ${field.Name}#if(${field.DefaultValue}) = #evaluate(${field.DefaultValue})#end;
-#end
-#macro(nonnull $before $after)#if(!${field.Nullable} && !${field.Primitive})$!before@NonNull$!after#end#end
-#macro(fielddoc)
-	#if(${field.DocString})
-	/**
-	 * $field.DocString.trim().replace("$newline", "$newline$tab *")
-	 */
+
+	## Literal tab
+	#set($tab = "	")
+
+	## Gobbles whitespace
+	#macro(noop)#end
+
+	## Use as a block macro to set the tab index of all lines in body.
+	#macro(settab $num)
+		#set($shift = "#foreach($i in [1..$num])$tab#end")
+		#noop$shift$bodyContent.toString().replace("$tab", "").replace("$newline", "$newline$shift").trim()
+	#end
+
+	## Use as a block macro to remove the first newline in the body.
+	## Useful when having foreach and output on the same line is unreadable but
+	## output is intended to be all on one line.
+	#macro(nonewline)$bodyContent.toString().replaceFirst("\n", "")#end
+
+	## Join a list
+	#macro(join $sep $list)
+		#foreach($element in $list)#@nonewline
+			#noop$element$sep
+		#end#end
+	#end
+
+	## Field helpers ##
+
+	## Get evaluated field type
+	#macro(fieldtype)#evaluate(${field.Type})#end
+
+	## Get field declaration
+	#macro(fielddecl)
+		#@settab(1)
+		#join(" ", ${field.Annotations})#join(" ", ${field.Modifiers})#fieldtype() ${field.Name}#if(${field.DefaultValue}) = #evaluate(${field.DefaultValue})#end;
+		#end
+	#end
+
+	## Return @NonNull if field should have it, otherwise return empty string
+	#macro(nonnull $before $after)#if(!${field.Nullable} && !${field.Primitive})$!before@NonNull$!after#end#end
+
+	## Get field doc comment
+	#macro(fielddoc)
+		#if(${field.DocString})
+		#@settab(1)
+		/**
+		 * $field.DocString.trim().replace("$newline", "$newline$tab *")
+		 */
+		#end
+		#end
 	#end
 #end
-#macro(getterprefix)#if(${field.Type} == "boolean")is#{else}get#end#end

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/FieldTest.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/FieldTest.java
@@ -54,11 +54,11 @@ class FieldTest {
 			.type(String.class)
 			.build();
 		assertEquals("getTest", f.getGetterName());
-		Field fBool = Field.builder()
+		f = Field.builder()
 			.name("test")
 			.type(boolean.class)
 			.build();
-		assertEquals("isTest", fBool.getGetterName());
+		assertEquals("isTest", f.getGetterName());
 	}
 
 	/**
@@ -79,6 +79,11 @@ class FieldTest {
 			.alias(Field.builder().name("another").getter(true).build())
 			.build();
 		assertTrue(f.hasGetter());
+		f = Field.builder()
+			.name("test")
+			.getter(false)
+			.build();
+		assertFalse(f.hasGetter());
 	}
 
 	/**
@@ -99,5 +104,10 @@ class FieldTest {
 			.alias(Field.builder().name("another").getter(true).build())
 			.build();
 		assertEquals("getAnother", f.getAnyGetter());
+		f = Field.builder()
+			.name("test")
+			.getter(false)
+			.build();
+		assertNull(f.getAnyGetter());
 	}
 }

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/FieldTest.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/FieldTest.java
@@ -44,4 +44,60 @@ class FieldTest {
 		assertEquals(f, f2);
 	}
 
+	/**
+	 * Test getGetterName.
+	 */
+	@Test
+	void testGetterName() {
+		Field f = Field.builder()
+			.name("test")
+			.type(String.class)
+			.build();
+		assertEquals("getTest", f.getGetterName());
+		Field fBool = Field.builder()
+			.name("test")
+			.type(boolean.class)
+			.build();
+		assertEquals("isTest", fBool.getGetterName());
+	}
+
+	/**
+	 * Test hasGetter.
+	 */
+	@Test
+	void testHasGetter() {
+		Field f = Field.builder()
+			.name("test")
+			.type(String.class)
+			.getter(true)
+			.build();
+		assertTrue(f.hasGetter());
+		f = Field.builder()
+			.name("test")
+			.type(String.class)
+			.getter(false)
+			.alias(Field.builder().name("another").getter(true).build())
+			.build();
+		assertTrue(f.hasGetter());
+	}
+
+	/**
+	 * Test getAnyGetter.
+	 */
+	@Test
+	void testAnyGetter() {
+		Field f = Field.builder()
+			.name("test")
+			.type(String.class)
+			.getter(true)
+			.build();
+		assertEquals("getTest", f.getAnyGetter());
+		f = Field.builder()
+			.name("test")
+			.type(String.class)
+			.getter(false)
+			.alias(Field.builder().name("another").getter(true).build())
+			.build();
+		assertEquals("getAnother", f.getAnyGetter());
+	}
 }

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/AccessibilityPreserved.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/AccessibilityPreserved.java
@@ -1,5 +1,11 @@
 @Data
 @NoArgsConstructor
+@JsonAutoDetect(
+	fieldVisibility = Visibility.ANY,
+	getterVisibility = Visibility.NONE,
+	isGetterVisibility = Visibility.NONE,
+	setterVisibility = Visibility.NONE
+)
 public class TestImplementation implements Test, Serializable {
 	public int shouldBePublic;
 	protected int shouldBeProtected;

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultNonStringImplementation.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultNonStringImplementation.java
@@ -1,5 +1,11 @@
 @Data
 @NoArgsConstructor
+@JsonAutoDetect(
+	fieldVisibility = Visibility.ANY,
+	getterVisibility = Visibility.NONE,
+	isGetterVisibility = Visibility.NONE,
+	setterVisibility = Visibility.NONE
+)
 public class TestImplementation implements Test, Serializable {
 	public int testInt = 42;
 }

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultStringImplementation.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultStringImplementation.java
@@ -1,5 +1,11 @@
 @Data
 @NoArgsConstructor
+@JsonAutoDetect(
+	fieldVisibility = Visibility.ANY,
+	getterVisibility = Visibility.NONE,
+	isGetterVisibility = Visibility.NONE,
+	setterVisibility = Visibility.NONE
+)
 public class TestImplementation implements Test, Serializable {
 	@NonNull public java.lang.String test = "A String Value";
 }

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultsImplementation.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DefaultsImplementation.java
@@ -1,5 +1,11 @@
 @Data
 @NoArgsConstructor
+@JsonAutoDetect(
+	fieldVisibility = Visibility.ANY,
+	getterVisibility = Visibility.NONE,
+	isGetterVisibility = Visibility.NONE,
+	setterVisibility = Visibility.NONE
+)
 public class TestImplementation implements Test, Serializable {
 	@NonNull
 	@Getter(AccessLevel.NONE)

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/ManyImplementation.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/ManyImplementation.java
@@ -1,5 +1,11 @@
 @Data
 @NoArgsConstructor
+@JsonAutoDetect(
+	fieldVisibility = Visibility.ANY,
+	getterVisibility = Visibility.NONE,
+	isGetterVisibility = Visibility.NONE,
+	setterVisibility = Visibility.NONE
+)
 public class TestImplementation implements Test, Serializable {
 	public byte testByte;
 	public short testShort;

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/ManyNonPrimitiveImplementation.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/ManyNonPrimitiveImplementation.java
@@ -1,5 +1,11 @@
 @Data
 @NoArgsConstructor
+@JsonAutoDetect(
+	fieldVisibility = Visibility.ANY,
+	getterVisibility = Visibility.NONE,
+	isGetterVisibility = Visibility.NONE,
+	setterVisibility = Visibility.NONE
+)
 public class TestImplementation implements Test, Serializable {
 	@NonNull public java.util.UUID testUuid;
 	@NonNull public java.lang.String testString;

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/SingleImplementation.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/SingleImplementation.java
@@ -1,5 +1,11 @@
 @Data
 @NoArgsConstructor
+@JsonAutoDetect(
+	fieldVisibility = Visibility.ANY,
+	getterVisibility = Visibility.NONE,
+	isGetterVisibility = Visibility.NONE,
+	setterVisibility = Visibility.NONE
+)
 public class TestImplementation implements Test, Serializable {
 	public int testInt;
 }

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/SingleNonPrimitiveImplementation.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/SingleNonPrimitiveImplementation.java
@@ -1,5 +1,11 @@
 @Data
 @NoArgsConstructor
+@JsonAutoDetect(
+	fieldVisibility = Visibility.ANY,
+	getterVisibility = Visibility.NONE,
+	isGetterVisibility = Visibility.NONE,
+	setterVisibility = Visibility.NONE
+)
 public class TestImplementation implements Test, Serializable {
 	@NonNull public java.util.UUID testUuid;
 }


### PR DESCRIPTION
This PR shuffles around our serialization logic to enable directly serializing or deserializing DataElements using Jackson. This will hopefully enable better integration of DataElements with other frameworks such as Drop Wizard.

As a summary of the changes, rather than directly interacting with `JsonNode`s, DataElements are now annotated to inform Jackson how to serialize it. DataElements are now also generated with a constructor annotated with `@JsonCreator` to mark it as the constructor to use for deserialization.