### PR TITLE
Quick fixes for renderer project

### DIFF
--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/PersistenceHandler.vm
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/PersistenceHandler.vm
@@ -64,7 +64,7 @@ public class $class implements $interface<$elementInterface> {
 	@Override
 	public Iterable<$elementInterface> findAll() throws Exception {
 		return this.collection.find()
-			.map(doc -> mapper.readValue(doc, ${implementation}.class);
+			.map(doc -> mapper.convertValue(doc, ${implementation}.class));
 	}
 
 	/**
@@ -99,7 +99,7 @@ public class $class implements $interface<$elementInterface> {
 			return null;
 		}
 
-		return mapper.readValue(doc, ${implementation}.class);
+		return mapper.convertValue(doc, ${implementation}.class);
 	}
 	#else
 
@@ -113,7 +113,7 @@ public class $class implements $interface<$elementInterface> {
 	#end
 	public Iterable<$elementInterface> findBy${var.NameForMethod}(${var.Type} ${var.Name}) throws Exception {
 		return this.collection.find(PersistenceFilters.eq("${var.Name}", ${var.Name}))
-			.map(doc -> mapper.readValue(doc, ${implementation}.class));
+			.map(doc -> mapper.convertValue(doc, ${implementation}.class));
 	}
 	#end## if unique
 	#end## if getter and search

--- a/org.eclipse.ice.renderer/pom.xml
+++ b/org.eclipse.ice.renderer/pom.xml
@@ -26,7 +26,7 @@
 							<version>2.16</version>
 						</path>
 						<path>
-							<groupId>org.eclipse.ice</groupId>
+							<groupId>org.eclipse.ice.dev</groupId>
 							<artifactId>org.eclipse.ice.dev.annotations</artifactId>
 							<version>3.0.0-SNAPSHOT</version>
 						</path>
@@ -56,7 +56,7 @@
 			<version>2.16</version>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.ice</groupId>
+			<groupId>org.eclipse.ice.dev</groupId>
 			<artifactId>org.eclipse.ice.dev.annotations</artifactId>
 			<version>3.0.0-SNAPSHOT</version>
 			<scope>provided</scope>

--- a/org.eclipse.ice.renderer/src/test/java/org/eclipse/ice/tests/renderer/GeneratedDataElementTest.java
+++ b/org.eclipse.ice.renderer/src/test/java/org/eclipse/ice/tests/renderer/GeneratedDataElementTest.java
@@ -171,7 +171,7 @@ class GeneratedDataElementTest {
 
 		// Because of the private id changing and being unique, this cannot be checked
 		// against a reference but can only be checked by inversion.
-		String output = element.toJSON();
+		String output = element.toJson();
 
 		// Change some values then read back in the original to make sure fromString()
 		// correctly overwrites them.
@@ -179,8 +179,8 @@ class GeneratedDataElementTest {
 		System.out.println(output);
 		GeneratedDataElement element2 = getStringElement("Emancipator");
 		element2.setValidator(new JavascriptValidator<GeneratedDataElement>());
-		element2.fromJSON(output);
-		element.fromJSON(output);
+		element2.fromJson(output);
+		element.fromJson(output);
 		assertEquals(element,element2);
 
 		return;
@@ -202,7 +202,7 @@ class GeneratedDataElementTest {
 
 		// Because of the private id changing and being unique, this cannot be checked
 		// against a reference but can only be checked by inversion.
-		String output = element.toJSON();
+		String output = element.toJson();
 
 		// Change some values then read back in the original to make sure fromString()
 		// correctly overwrites them.
@@ -211,7 +211,7 @@ class GeneratedDataElementTest {
 		pojo2.setDoubleValue(1.072);
 		element2.setValidator(new JavascriptValidator<GeneratedDataElementPOJO>());
 		element2.setTestPOJO(pojo2);
-		element2.fromJSON(output);
+		element2.fromJson(output);
 
 		assertEquals(element,element2);
 


### PR DESCRIPTION
Some quick fixes for org.eclipse.ice.renderer. My recent JSON PR had some errors in the persistence template that went uncaught in the proxytest module as tests for persistence aren't implemented yet. In the future, the tests in renderer should probably just be removed but this gets things working again for now.