### PR TITLE
Annotation processor logging

### DIFF
--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/pom.xml
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/pom.xml
@@ -102,6 +102,11 @@
 			<version>3.0.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.cosium.logging</groupId>
+			<artifactId>annotation-processor-logger</artifactId>
+			<version>1.0</version>
+		</dependency>
 	</dependencies>
 
 	<parent>

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/DataElementProcessor.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/DataElementProcessor.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
@@ -28,6 +27,7 @@ import javax.tools.StandardLocation;
 import org.eclipse.ice.dev.annotations.DataElement;
 import org.eclipse.ice.dev.annotations.Persisted;
 
+import com.cosium.logging.annotation_processor.AbstractLoggingProcessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
 
@@ -46,7 +46,7 @@ import com.google.auto.service.AutoService;
 })
 @SupportedSourceVersion(SourceVersion.RELEASE_11)
 @AutoService(Processor.class)
-public class DataElementProcessor extends AbstractProcessor {
+public class DataElementProcessor extends AbstractLoggingProcessor {
 	/**
 	 * Return stack trace as string.
 	 * @param e subject exception
@@ -73,7 +73,7 @@ public class DataElementProcessor extends AbstractProcessor {
 	}
 
 	@Override
-	public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+	public boolean doProcess(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
 		// Iterate over all elements with DataElement Annotation
 		for (final Element elem : roundEnv.getElementsAnnotatedWith(DataElement.class)) {
 			try {

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/VelocityProperties.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/VelocityProperties.java
@@ -11,61 +11,55 @@
 
 package org.eclipse.ice.dev.annotations.processors;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Properties used to initialize Velocity.
  */
-enum VelocityProperties {
-
-	// Set up Velocity using the Singleton approach; ClasspathResourceLoader allows
-	// us to load templates from src/main/resources
-	RESOURCE_LOADER("resource.loader", "class"),
-	CLASS_RESOURCE_LOADER(
-		"class.resource.loader.class",
-		"org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader"
-	);
+class VelocityProperties extends Properties {
 
 	/**
-	 * Property key.
+	 * Serial Version ID.
 	 */
-	private String key;
+	private static final long serialVersionUID = 1L;
 
 	/**
-	 * Property value.
+	 * Logger.
 	 */
-	private String value;
-
-	VelocityProperties(String key, String value) {
-		this.key = key;
-		this.value = value;
-	}
+	private static final Logger logger = LoggerFactory.getLogger(VelocityProperties.class);
 
 	/**
-	 * Get key from enum.
-	 * @return key
+	 * Velocity property filename.
 	 */
-	String key() {
-		return this.key;
-	}
+	private static final String FILENAME = "velocity.properties";
+
+	private static VelocityProperties instance = null;
 
 	/**
-	 * Get value from enum.
-	 * @return value
+	 * Construct VelocityProperties, loading from resource file.
 	 */
-	String value() {
-		return this.value;
-	}
-
-	/**
-	 * Generate and return Properties from enum.
-	 * @return Properties
-	 */
-	public static Properties get() {
-		Properties p = new Properties();
-		for (VelocityProperties vp : VelocityProperties.values()) {
-			p.setProperty(vp.key(), vp.value());
+	private VelocityProperties() {
+		String propertyFile = getClass().getClassLoader().getResource(FILENAME).getPath();
+		try (InputStream propertyStream = new FileInputStream(propertyFile)) {
+			super.load(propertyStream);
+		} catch (FileNotFoundException e) {
+			logger.error("velocity.properties could not be found");
+		} catch (IOException e) {
+			logger.error("velocity.properties could not be read");
 		}
-		return p;
+	}
+
+	public static VelocityProperties get() {
+		if (instance == null) {
+			instance = new VelocityProperties();
+		}
+		return instance;
 	}
 }

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/velocity.properties
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/velocity.properties
@@ -1,0 +1,3 @@
+resource.loaders=class
+resource.loader.class.class=org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader
+velocimacro.library.path=templates/common.vm

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/DataElementProcessorTest.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/DataElementProcessorTest.java
@@ -220,6 +220,7 @@ class DataElementProcessorTest {
 	@Test
 	void testNoDataFieldsSucceeds() {
 		Compilation compilation = helper.compile(Inputs.NO_DATAFIELDS.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertDefaultsPresent(compilation);
 	}
 
@@ -229,6 +230,7 @@ class DataElementProcessorTest {
 	@Test
 	void testWithSingleDataFieldSucceeds() {
 		Compilation compilation = helper.compile(Inputs.SINGLE.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertDefaultsPresent(compilation);
 		assertInterfaceMatches(compilation, Patterns.SINGLE_INT.get());
 		assertImplementationMatches(compilation, Patterns.SINGLE_IMPL.get());
@@ -240,6 +242,7 @@ class DataElementProcessorTest {
 	@Test
 	void testWithManyDataFieldsSucceeds() {
 		Compilation compilation = helper.compile(Inputs.MANY.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertDefaultsPresent(compilation);
 		assertInterfaceMatches(compilation, Patterns.MANY_INT.get());
 		assertImplementationMatches(compilation, Patterns.MANY_IMPL.get());
@@ -251,6 +254,7 @@ class DataElementProcessorTest {
 	@Test
 	void testSingleNonPrimitiveDataFieldSucceeds() {
 		Compilation compilation = helper.compile(Inputs.SINGLE_NON_PRIMITIVE.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertDefaultsPresent(compilation);
 		assertInterfaceMatches(compilation, Patterns.SINGLE_NON_PRIMITIVE_INT.get());
 		assertImplementationMatches(compilation, Patterns.SINGLE_NON_PRIMITIVE_IMPL.get());
@@ -262,6 +266,7 @@ class DataElementProcessorTest {
 	@Test
 	void testManyNonPrimitiveDataFieldSucceeds() {
 		Compilation compilation = helper.compile(Inputs.MANY_NON_PRIMITIVE.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertDefaultsPresent(compilation);
 		assertInterfaceMatches(compilation, Patterns.MANY_NON_PRIMITIVE_INT.get());
 		assertImplementationMatches(compilation, Patterns.MANY_NON_PRIMITIVE_IMPL.get());
@@ -274,6 +279,7 @@ class DataElementProcessorTest {
 	@Test
 	void testDocStringsPreserved() {
 		Compilation compilation = helper.compile(Inputs.SINGLE.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertThat(compilation).generatedSourceFile(IMPLEMENTATION)
 			.contentsAsUtf8String()
 			.contains("* A UNIQUE STRING IN THE DOC STRING.");
@@ -289,6 +295,7 @@ class DataElementProcessorTest {
 	@Test
 	void testAccessibilityPreserved() {
 		Compilation compilation = helper.compile(Inputs.ACCESSIBILITY_PRESERVED.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertImplementationMatches(compilation, Patterns.ACCESSIBILITY_PRESERVED.get());
 	}
 
@@ -321,6 +328,7 @@ class DataElementProcessorTest {
 	@Test
 	void testDataFieldGetterOption() {
 		Compilation compilation = helper.compile(Inputs.DATAFIELD_GETTER.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertThat(compilation)
 			.generatedSourceFile(INTERFACE)
 			.hasSourceEquivalentTo(Patterns.DATAFIELD_GETTER_INT.get());
@@ -332,6 +340,7 @@ class DataElementProcessorTest {
 	@Test
 	void testDataFieldSetterOption() {
 		Compilation compilation = helper.compile(Inputs.DATAFIELD_SETTER.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertThat(compilation)
 			.generatedSourceFile(INTERFACE)
 			.hasSourceEquivalentTo(Patterns.DATAFIELD_SETTER_INT.get());
@@ -343,6 +352,7 @@ class DataElementProcessorTest {
 	@Test
 	void testDataFieldMatchOption() {
 		Compilation compilation = helper.compile(Inputs.DATAFIELD_MATCH.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertThat(compilation)
 			.generatedSourceFile(IMPLEMENTATION)
 			.contentsAsUtf8String()
@@ -359,6 +369,7 @@ class DataElementProcessorTest {
 	@Test
 	void testDataFieldDefaultNonString() {
 		Compilation compilation = helper.compile(Inputs.DEFAULT_NON_STRING.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertImplementationMatches(
 			compilation,
 			Patterns.DEFAULT_NON_STRING_IMPL.get()
@@ -371,6 +382,7 @@ class DataElementProcessorTest {
 	@Test
 	void testDataFieldDefaultString() {
 		Compilation compilation = helper.compile(Inputs.DEFAULT_STRING.get());
+		assertThat(compilation).succeededWithoutWarnings();
 		assertImplementationMatches(
 			compilation,
 			Patterns.DEFAULT_STRING_IMPL.get()


### PR DESCRIPTION
This PR contains an experiment in propagating warnings and errors logged by libraries utilized by our annotation processors through the `javax.annotation.processing.Messager`. This ensures errors and warnings are not missed during compilation of clients and also makes it easier to catch these errors in our own testing.