### PR TITLE
Fix VelocityProperties and Annotation Processor Logging

### DIFF
--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/pom.xml
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/pom.xml
@@ -106,6 +106,7 @@
 			<groupId>com.cosium.logging</groupId>
 			<artifactId>annotation-processor-logger</artifactId>
 			<version>1.0</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/DataElementProcessor.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/DataElementProcessor.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2020- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Daniel Bluhm - Initial implementation
+ *******************************************************************************/
+
 package org.eclipse.ice.dev.annotations.processors;
 
 import java.io.IOException;
@@ -10,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
@@ -27,7 +39,6 @@ import javax.tools.StandardLocation;
 import org.eclipse.ice.dev.annotations.DataElement;
 import org.eclipse.ice.dev.annotations.Persisted;
 
-import com.cosium.logging.annotation_processor.AbstractLoggingProcessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
 
@@ -46,7 +57,7 @@ import com.google.auto.service.AutoService;
 })
 @SupportedSourceVersion(SourceVersion.RELEASE_11)
 @AutoService(Processor.class)
-public class DataElementProcessor extends AbstractLoggingProcessor {
+public class DataElementProcessor extends AbstractProcessor {
 	/**
 	 * Return stack trace as string.
 	 * @param e subject exception
@@ -73,7 +84,7 @@ public class DataElementProcessor extends AbstractLoggingProcessor {
 	}
 
 	@Override
-	public boolean doProcess(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+	public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
 		// Iterate over all elements with DataElement Annotation
 		for (final Element elem : roundEnv.getElementsAnnotatedWith(DataElement.class)) {
 			try {

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/VelocityProperties.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/VelocityProperties.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.ice.dev.annotations.processors;
 
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,8 +45,7 @@ class VelocityProperties extends Properties {
 	 * Construct VelocityProperties, loading from resource file.
 	 */
 	private VelocityProperties() {
-		String propertyFile = getClass().getClassLoader().getResource(FILENAME).getPath();
-		try (InputStream propertyStream = new FileInputStream(propertyFile)) {
+		try (InputStream propertyStream = getClass().getClassLoader().getResourceAsStream(FILENAME)) {
 			super.load(propertyStream);
 		} catch (FileNotFoundException e) {
 			logger.error("velocity.properties could not be found");

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/DataElementAnnotationTestHelper.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/DataElementAnnotationTestHelper.java
@@ -19,12 +19,9 @@ import javax.annotation.processing.Processor;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 
-import org.eclipse.ice.dev.annotations.processors.DataElementProcessor;
-
 import com.google.testing.compile.Compilation;
 
 import static com.google.testing.compile.Compiler.*;
-import static com.google.testing.compile.CompilationSubject.*;
 
 /**
  * Helper class for testing DataElement related annotations.
@@ -88,7 +85,7 @@ public class DataElementAnnotationTestHelper {
 		Compilation compilation = javac()
 			.withProcessors(
 				getLombokAnnotationProcessor(),
-				new DataElementProcessor()
+				new LoggingDataElementProcessor()
 			).compile(sources);
 		if (showDiagnostics) {
 			printDiagnostics(compilation);

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/LoggingDataElementProcessor.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/LoggingDataElementProcessor.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020- UT-Battelle, LLC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Daniel Bluhm - Initial implementation
+ *******************************************************************************/
+
+package org.eclipse.ice.tests.dev.annotations.processors;
+
+import java.util.Set;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+import org.eclipse.ice.dev.annotations.processors.DataElementProcessor;
+
+import com.cosium.logging.annotation_processor.AbstractLoggingProcessor;
+
+/**
+ * Wrapper around DataElementProcessor used to catch warnings that would
+ * normally be missed.
+ * @author Daniel Bluhm
+ */
+@SupportedAnnotationTypes({
+	"org.eclipse.ice.dev.annotations.DataElement",
+	"org.eclipse.ice.dev.annotations.DataField",
+	"org.eclipse.ice.dev.annotations.DataField.Default",
+	"org.eclipse.ice.dev.annotations.Persisted"
+})
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
+public class LoggingDataElementProcessor extends AbstractLoggingProcessor {
+
+	/**
+	 * Wrapped processor.
+	 */
+	private DataElementProcessor wrappedProcessor = new DataElementProcessor();
+
+	@Override
+	public void init(final ProcessingEnvironment env) {
+		wrappedProcessor.init(env);
+		super.init(env);
+	}
+
+	@Override
+	protected boolean doProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+		return wrappedProcessor.process(annotations, roundEnv);
+	}
+}

--- a/org.eclipse.ice.tests.integration/org.eclipse.ice.tests.integration.dev.annotation/pom.xml
+++ b/org.eclipse.ice.tests.integration/org.eclipse.ice.tests.integration.dev.annotation/pom.xml
@@ -34,7 +34,7 @@
 			<version>3.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.ice.dev</groupId>
+			<groupId>org.eclipse.ice</groupId>
 			<artifactId>org.eclipse.ice.dev.annotations</artifactId>
 			<version>3.0.0-SNAPSHOT</version>
 		</dependency>


### PR DESCRIPTION
This PR fixes two issues:
- VelocityProperties was set to load from a file when it should have been loading from a resource
- Annotation processor logging the way I set it up would conflict with any logger implementations put on dependent projects. I reverted the main `DataElementProcessor` to extend the usual `AbstractProcessor` and wrote a quick wrapper around it for use in testing that adds in the logging functionality. With that in place, the annotation-processor-logging library is a test only dependency, solving our logger conflict problems.