### PR TITLE
Fix builds, revert JavascriptValidator generics removal

### DIFF
--- a/org.eclipse.ice.build/pom.xml
+++ b/org.eclipse.ice.build/pom.xml
@@ -1,31 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-  <parent>
-  	<groupId>org.eclipse.ice</groupId>
-  	<artifactId>org.eclipse.ice.parent</artifactId>
-  	<version>2.2.1-SNAPSHOT</version>
-  	<relativePath>../org.eclipse.ice.parent/pom.xml</relativePath>
-  </parent>
-  <groupId>org.eclipse.ice</groupId>
-  <artifactId>org.eclipse.ice.build</artifactId>
-  <version>1.0-SNAPSHOT</version>
-  <packaging>pom</packaging>
+	<parent>
+		<groupId>org.eclipse.ice</groupId>
+		<artifactId>org.eclipse.ice.parent</artifactId>
+		<version>2.2.1-SNAPSHOT</version>
+		<relativePath>../org.eclipse.ice.parent/pom.xml</relativePath>
+	</parent>
+	<artifactId>org.eclipse.ice.build</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
 
-  <name>org.eclipse.ice.build</name>
+	<name>org.eclipse.ice.build</name>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 
-  <modules>
-  	<module>../org.eclipse.ice.parent</module>
-  	<module>../org.eclipse.ice.dev</module>
-  	<module>../org.eclipse.ice.archetypes</module>
-    <module>../org.eclipse.ice.commands</module>
-  
-  </modules>
+	<modules>
+		<module>../org.eclipse.ice.parent</module>
+		<module>../org.eclipse.ice.data</module>
+		<module>../org.eclipse.ice.dev</module>
+		<module>../org.eclipse.ice.archetypes</module>
+		<module>../org.eclipse.ice.commands</module>
+	</modules>
 </project>

--- a/org.eclipse.ice.build/pom.xml
+++ b/org.eclipse.ice.build/pom.xml
@@ -4,14 +4,9 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.eclipse.ice</groupId>
-		<artifactId>org.eclipse.ice.parent</artifactId>
-		<version>2.2.1-SNAPSHOT</version>
-		<relativePath>../org.eclipse.ice.parent/pom.xml</relativePath>
-	</parent>
+	<groupId>org.eclipse.ice</groupId>
 	<artifactId>org.eclipse.ice.build</artifactId>
-	<version>1.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>org.eclipse.ice.build</name>
@@ -21,7 +16,6 @@
 	</properties>
 
 	<modules>
-		<module>../org.eclipse.ice.parent</module>
 		<module>../org.eclipse.ice.data</module>
 		<module>../org.eclipse.ice.dev</module>
 		<module>../org.eclipse.ice.archetypes</module>

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileHandler.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileHandler.java
@@ -9,7 +9,7 @@
  *   Initial API and implementation and/or initial documentation - Jay Jay Billings,
  *   Joe Osborn
  *******************************************************************************/
-package org.eclipse.ice.tests.commands;
+package org.eclipse.ice.commands;
 
 import java.io.File;
 import java.io.IOException;

--- a/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileTransferCommand.java
+++ b/org.eclipse.ice.commands/src/main/java/org/eclipse/ice/commands/RemoteRemoteFileTransferCommand.java
@@ -9,7 +9,7 @@
  *   Initial API and implementation and/or initial documentation - 
  *   Jay Jay Billings, Joe Osborn
  *******************************************************************************/
-package org.eclipse.ice.tests.commands;
+package org.eclipse.ice.commands;
 
 import java.io.File;
 import java.io.IOException;

--- a/org.eclipse.ice.data/src/main/java/org/eclipse/ice/data/JavascriptValidator.java
+++ b/org.eclipse.ice.data/src/main/java/org/eclipse/ice/data/JavascriptValidator.java
@@ -46,7 +46,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * @author Jay Jay Billings
  *
  */
-public class JavascriptValidator implements Serializable {
+public class JavascriptValidator<T> implements Serializable {
 
 	/**
 	 * Logging tool
@@ -88,7 +88,7 @@ public class JavascriptValidator implements Serializable {
 	 * Copy constructor
 	 * @param otherValidator to copy
 	 */
-	public JavascriptValidator(JavascriptValidator otherValidator) {
+	public JavascriptValidator(JavascriptValidator<T> otherValidator) {
 		if (otherValidator != null) {
 			function = otherValidator.function;
 		}
@@ -138,7 +138,7 @@ public class JavascriptValidator implements Serializable {
 			retValue = true;
 		} else if (otherObject instanceof JavascriptValidator) {
 			@SuppressWarnings("unchecked")
-			JavascriptValidator otherValidator = (JavascriptValidator) otherObject;
+			JavascriptValidator<T> otherValidator = (JavascriptValidator<T>) otherObject;
 			retValue = this.function.equals(otherValidator.function);
 		}
 
@@ -153,7 +153,7 @@ public class JavascriptValidator implements Serializable {
 	 * @throws NoSuchMethodException This exception is thrown if the Javascript
 	 *                               validation function cannot be found.
 	 */
-	public boolean validate(final IDataElement data) throws NoSuchMethodException {
+	public boolean validate(final T data) throws NoSuchMethodException {
 
 		boolean retValue = false;
 		Object result = null;
@@ -196,7 +196,7 @@ public class JavascriptValidator implements Serializable {
 	public Object clone() {
 		try {
 			// Call the copy constructor to create the clone.
-			return new JavascriptValidator(this);
+			return new JavascriptValidator<T>(this);
 		} catch (Exception e) {
 			logger.error("Unable to clone DataElement!", e);
 			return null;

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations.proxytest/src/test/java/org/eclipse/ice/dev/annotations/proxytest/GeneratedDataElementTest.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations.proxytest/src/test/java/org/eclipse/ice/dev/annotations/proxytest/GeneratedDataElementTest.java
@@ -99,7 +99,7 @@ class GeneratedDataElementTest {
 		assertEquals(element.isSecret(), secret);
 
 		// Make sure that adding validators works superficially
-		JavascriptValidator validator = new JavascriptValidator();
+		JavascriptValidator<GeneratedDataElement> validator = new JavascriptValidator<>();
 		element.setValidator(validator);
 		assertEquals(element.getValidator(), validator);
 
@@ -167,7 +167,7 @@ class GeneratedDataElementTest {
 		GeneratedDataElement element = getStringElement("Major Lazer & La Roux");
 		element.setSecret(true);
 		element.setRequired(true);
-		element.setValidator(new JavascriptValidator());
+		element.setValidator(new JavascriptValidator<>());
 
 		// Because of the private id changing and being unique, this cannot be checked
 		// against a reference but can only be checked by inversion.
@@ -178,7 +178,7 @@ class GeneratedDataElementTest {
 		element.setTestField("Eastern Sun");
 		System.out.println(output);
 		GeneratedDataElement element2 = getStringElement("Emancipator");
-		element2.setValidator(new JavascriptValidator());
+		element2.setValidator(new JavascriptValidator<>());
 		element2.fromJson(output);
 		element.fromJson(output);
 		assertEquals(element,element2);
@@ -198,7 +198,7 @@ class GeneratedDataElementTest {
 		element.setTestPOJO(new TestPOJO());
 		element.setSecret(true);
 		element.setRequired(true);
-		element.setValidator(new JavascriptValidator());
+		element.setValidator(new JavascriptValidator<>());
 
 		// Because of the private id changing and being unique, this cannot be checked
 		// against a reference but can only be checked by inversion.
@@ -209,7 +209,7 @@ class GeneratedDataElementTest {
 		GeneratedDataElementPOJO element2 = new GeneratedDataElementPOJOImplementation();
 		TestPOJO pojo2 = new TestPOJO();
 		pojo2.setDoubleValue(1.072);
-		element2.setValidator(new JavascriptValidator());
+		element2.setValidator(new JavascriptValidator<>());
 		element2.setTestPOJO(pojo2);
 		element2.fromJson(output);
 
@@ -236,12 +236,12 @@ class GeneratedDataElementTest {
 		GeneratedDataElement element4 = getStringElement("Halsey");
 
 		// Need a validator for the tests that is shared on the equal elements.
-		JavascriptValidator validator = new JavascriptValidator();
+		JavascriptValidator<GeneratedDataElement> validator = new JavascriptValidator<>();
 		element.setValidator(validator);
 		element2.setValidator(validator);
 		element4.setValidator(validator);
 		// Billie needs her own validator
-		element3.setValidator(new JavascriptValidator());
+		element3.setValidator(new JavascriptValidator<>());
 
 		// Data elements must be checked both for matching - a deep inequality except
 		// the UUID - and for a fully complete match that contains the UUID. Start with

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/DefaultFields.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/DefaultFields.java
@@ -113,7 +113,7 @@ public class DefaultFields {
 	 */
 	private static Field validator = Field.builder()
 		.name("validator")
-		.type(JavascriptValidator.class)
+		.type(JavascriptValidator.class.getCanonicalName() + "<$interface>")
 		.docString("The validator used to check the correctness of the data.")
 		.nullable(true)
 		.defaultField(true)

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/Types.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/java/org/eclipse/ice/dev/annotations/processors/Types.java
@@ -120,7 +120,7 @@ public class Types {
 			matcher.appendReplacement(shortenedType, "$1");
 		}
 		matcher.appendTail(shortenedType);
-		return shortenedType.toString().replace("$", ".");
+		return shortenedType.toString();
 	}
 
 	/**
@@ -135,6 +135,7 @@ public class Types {
 			.map(entry -> entry.getValue())
 			// No need to import java.lang package
 			.filter(type -> !type.startsWith("java.lang"))
+			.filter(type -> !type.startsWith("$"))
 			.collect(Collectors.toSet());
 	}
 
@@ -148,9 +149,13 @@ public class Types {
 		StringBuffer resolved = new StringBuffer();
 		Matcher matcher = TYPE_SHORTENER.matcher(type);
 		while (matcher.find()) {
+			String found = fullToShort.get(matcher.group());
+			if (found == null) {
+				found = matcher.group();
+			}
 			matcher.appendReplacement(
 				resolved,
-				fullToShort.get(matcher.group())
+				found
 			);
 		}
 		matcher.appendTail(resolved);

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/common.vm
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/main/resources/templates/common.vm
@@ -44,7 +44,7 @@
 #end
 
 ## Get evaluated field type
-#macro(fieldtype)$types.resolve(${field.Type})#end
+#macro(fieldtype)$types.resolve("#evaluate(${field.Type})")#end
 
 ## Get the type of this field for use in parameter list (includes nonnull)
 #macro(fieldparametertype)#nonnull("", " ")#fieldtype#end

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/TypesTest.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/java/org/eclipse/ice/tests/dev/annotations/processors/TypesTest.java
@@ -30,8 +30,8 @@ class TypesTest {
 		assertEquals("UUID", Types.getShortenedType("java.util.UUID"));
 		assertEquals("Entry", Types.getShortenedType("java.util.Map.Entry"));
 		assertEquals(
-			"Map.Entry<String, Object>",
-			Types.getShortenedType("java.util.Map$Entry<String, Object>")
+			"Entry<String, Object>",
+			Types.getShortenedType("java.util.Map.Entry<String, Object>")
 		);
 		assertEquals(
 			"List<String>",

--- a/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DataElement/DefaultsImplementation.java
+++ b/org.eclipse.ice.dev/org.eclipse.ice.dev.annotations/src/test/resources/patterns/DataElement/DefaultsImplementation.java
@@ -19,5 +19,5 @@ public class TestImplementation implements Test, Serializable {
 	@NonNull protected String context = "default";
 	protected boolean required = false;
 	protected boolean secret = false;
-	protected JavascriptValidator validator;
+	protected JavascriptValidator<Test> validator;
 }


### PR DESCRIPTION
I added `org.eclipse.ice.data` to the build and discovered there were more issues with JavascriptValidator than I originally thought. I reverted the removal of the generics and fixed my type lookup mechanism to accommodate passing through values to be interpolated by velocity. I'm not particularly fond of that need but I think it's better to just fix the issues and address the bigger issue down the road.