### PR TITLE
fix: potential null pointer dereference

### DIFF
--- a/org.eclipse.ice.vibe/src/org/eclipse/ice/vibe/kvPair/VibeKVPair.java
+++ b/org.eclipse.ice.vibe/src/org/eclipse/ice/vibe/kvPair/VibeKVPair.java
@@ -623,8 +623,10 @@ public class VibeKVPair extends Item implements IReader, IWriter {
 		}
 
 		// Register each dependent row as a listener to the NUMSEG row
-		for (VibeKVPairRow dependentRow : dependentRows) {
-			numsegRow.register(dependentRow);
+		if (numsegRow != null) {
+			for (VibeKVPairRow dependentRow : dependentRows) {
+				numsegRow.register(dependentRow);
+			}
 		}
 
 		//Add the table to the form if it isn't already there


### PR DESCRIPTION
##### Motivation:
In file: VibeKVPair.java, class: VibeKVPair, there is a method read that there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program.

##### Potential Null Dereference Path
In the same file at line 501,  the value of variable numsegRow was initialized as null
```java
VibeKVPairRow numsegRow = null;
```
And only once a value was assigned to it at line 519 inside an `logical if` statement.
```java
if (!dependentKeys.contains(keyValue[0])) {
	if ("NUMSEG".equals(keyValue[0])) {
                // ...
		numsegRow = entryRow;
               // ...
	}
       else {
               // ...
       }
}
```

If the `if` statement is escaped then the value of numsegRow reamins null and later it can raise a `NullPointerException` when dereferenced at
```java
// Register each dependent row as a listener to the NUMSEG row
for (VibeKVPairRow dependentRow : dependentRows) {
	numsegRow.register(dependentRow);
}
```
##### Fix:
Have an null check before dereferencing
```java
if (numsegRow != null) {
	for (VibeKVPairRow dependentRow : dependentRows) {
		numsegRow.register(dependentRow);
	}
}
```
also, manually `NullPointerException` can be handled.

##### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.